### PR TITLE
Fixed SLKTextViewController calls wrong super initializer

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -63,7 +63,7 @@
 
 - (instancetype)initWithTableViewStyle:(UITableViewStyle)style
 {
-    if (self = [super init]) {
+    if (self = [super initWithNibName:nil bundle:nil]) {
         [self tableViewWithStyle:style];
         [self commonInit];
     }
@@ -72,7 +72,7 @@
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
 {
-    if (self = [super init]) {
+    if (self = [super initWithNibName:nil bundle:nil]) {
         [self collectionViewWithLayout:layout];
         [self commonInit];
     }


### PR DESCRIPTION
The designated initializer of `UIViewController` is [`initWithNibName:bundle:`](https://developer.apple.com/library/ios/Documentation/UIKit/Reference/UIViewController_Class/index.html#//apple_ref/occ/instm/UIViewController/initWithNibName:bundle:), not `init`.

When calling `[super init]` then `UIViewController` calls `[self initWithNibName:bundle:]` internally. Since it's calling on `self` the call goes back down in the inheritance hierarchy to the derived classes and then back up the hierarchy again.

This breaks the typical [initializer pattern](https://blog.twitter.com/2014/how-to-objective-c-initializer-patterns). It also crashes when deriving from `SLKTextViewController` in Swift (`fatal error: use of unimplemented initializer 'init(nibName:bundle:)' for class 'App.ChatConversationScreen'`) since the derived class has a different designated initializer and cannot be initialized twice.
