### PR TITLE
Prefixed all category methods and properties

### DIFF
--- a/Source/Additions/UIScrollView+SLKAdditions.h
+++ b/Source/Additions/UIScrollView+SLKAdditions.h
@@ -20,32 +20,32 @@
 @interface UIScrollView (SLKAdditions)
 
 /** YES if the scrollView's offset is at the very top. */
-@property (nonatomic, readonly) BOOL isAtTop;
+@property (nonatomic, readonly) BOOL slk_isAtTop;
 /** YES if the scrollView's offset is at the very bottom. */
-@property (nonatomic, readonly) BOOL isAtBottom;
+@property (nonatomic, readonly) BOOL slk_isAtBottom;
 /** YES if the scrollView can scroll from it's current offset position to the bottom. */
-@property (nonatomic, readonly) BOOL canScrollToBottom;
+@property (nonatomic, readonly) BOOL slk_canScrollToBottom;
 
 /** The vertical scroll indicator view. */
-@property (nonatomic, readonly) UIView *verticalScroller;
+@property (nonatomic, readonly) UIView *slk_verticalScroller;
 /** The horizontal scroll indicator view. */
-@property (nonatomic, readonly) UIView *horizontalScroller;
+@property (nonatomic, readonly) UIView *slk_horizontalScroller;
 
 /**
  Sets the content offset to the top.
  @param animated YES to animate the transition at a constant velocity to the new offset, NO to make the transition immediate.
  */
-- (void)scrollToTopAnimated:(BOOL)animated;
+- (void)slk_scrollToTopAnimated:(BOOL)animated;
 
 /**
  Sets the content offset to the bottom.
  @param animated YES to animate the transition at a constant velocity to the new offset, NO to make the transition immediate.
  */
-- (void)scrollToBottomAnimated:(BOOL)animated;
+- (void)slk_scrollToBottomAnimated:(BOOL)animated;
 
 /**
  Stops scrolling, if it was scrolling.
  */
-- (void)stopScrolling;
+- (void)slk_stopScrolling;
 
 @end

--- a/Source/Additions/UIScrollView+SLKAdditions.m
+++ b/Source/Additions/UIScrollView+SLKAdditions.m
@@ -22,34 +22,34 @@ static NSString * const kKeyScrollViewHorizontalIndicator = @"_horizontalScrollI
 
 @implementation UIScrollView (SLKAdditions)
 
-- (void)scrollToTopAnimated:(BOOL)animated
+- (void)slk_scrollToTopAnimated:(BOOL)animated
 {
-    if (![self isAtTop]) {
+    if (![self slk_isAtTop]) {
         CGPoint bottomOffset = CGPointZero;
         [self setContentOffset:bottomOffset animated:animated];
     }
 }
 
-- (void)scrollToBottomAnimated:(BOOL)animated
+- (void)slk_scrollToBottomAnimated:(BOOL)animated
 {
-    if ([self canScrollToBottom] && ![self isAtBottom]) {
+    if ([self slk_canScrollToBottom] && ![self slk_isAtBottom]) {
         CGPoint bottomOffset = CGPointMake(0.0, self.contentSize.height - self.bounds.size.height);
         [self setContentOffset:bottomOffset animated:animated];
     }
 }
 
-- (BOOL)isAtTop
+- (BOOL)slk_isAtTop
 {
     return (self.contentOffset.y == 0.0) ? YES : NO;
 }
 
-- (BOOL)isAtBottom
+- (BOOL)slk_isAtBottom
 {
     CGFloat bottomOffset = self.contentSize.height-self.bounds.size.height;
     return (self.contentOffset.y == bottomOffset) ? YES : NO;
 }
 
-- (BOOL)canScrollToBottom
+- (BOOL)slk_canScrollToBottom
 {
     if (self.contentSize.height > self.bounds.size.height) {
         return YES;
@@ -57,7 +57,7 @@ static NSString * const kKeyScrollViewHorizontalIndicator = @"_horizontalScrollI
     return NO;
 }
 
-- (void)stopScrolling
+- (void)slk_stopScrolling
 {
     if (!self.isDragging) {
         return;
@@ -71,25 +71,25 @@ static NSString * const kKeyScrollViewHorizontalIndicator = @"_horizontalScrollI
     [self setContentOffset:offset animated:NO];
 }
 
-- (UIView *)verticalScroller
+- (UIView *)slk_verticalScroller
 {
     if (objc_getAssociatedObject(self, _cmd) == nil) {
-        objc_setAssociatedObject(self, _cmd, [self safeValueForKey:kKeyScrollViewVerticalIndicator], OBJC_ASSOCIATION_ASSIGN);
+        objc_setAssociatedObject(self, _cmd, [self slk_safeValueForKey:kKeyScrollViewVerticalIndicator], OBJC_ASSOCIATION_ASSIGN);
     }
     
     return objc_getAssociatedObject(self, _cmd);
 }
 
-- (UIView *)horizontalScroller
+- (UIView *)slk_horizontalScroller
 {
     if (objc_getAssociatedObject(self, _cmd) == nil) {
-        objc_setAssociatedObject(self, _cmd, [self safeValueForKey:kKeyScrollViewHorizontalIndicator], OBJC_ASSOCIATION_ASSIGN);
+        objc_setAssociatedObject(self, _cmd, [self slk_safeValueForKey:kKeyScrollViewHorizontalIndicator], OBJC_ASSOCIATION_ASSIGN);
     }
     
     return objc_getAssociatedObject(self, _cmd);
 }
 
-- (id)safeValueForKey:(NSString *)key
+- (id)slk_safeValueForKey:(NSString *)key
 {
     Ivar instanceVariable = class_getInstanceVariable([self class], [key cStringUsingEncoding:NSUTF8StringEncoding]);
     return object_getIvar(self, instanceVariable);

--- a/Source/Additions/UITextView+SLKAdditions.h
+++ b/Source/Additions/UITextView+SLKAdditions.h
@@ -20,33 +20,33 @@
 @interface UITextView (SLKAdditions)
 
 /** The current displayed number of lines. */
-@property (nonatomic, readonly) NSUInteger numberOfLines;
+@property (nonatomic, readonly) NSUInteger slk_numberOfLines;
 
 /**
  Scrolls to the very end of the content size, animated.
  
  @param animated YES if the scrolling should be animated.
  */
-- (void)scrollToBottomAnimated:(BOOL)animated;
+- (void)slk_scrollToBottomAnimated:(BOOL)animated;
 
 /**
  Scrolls to the caret position, animated.
  
  @param animated YES if the scrolling should be animated.
  */
-- (void)scrollToCaretPositonAnimated:(BOOL)animated;
+- (void)slk_scrollToCaretPositonAnimated:(BOOL)animated;
 
 /**
  Inserts a line break at the caret's position.
  */
-- (void)insertNewLineBreak;
+- (void)slk_insertNewLineBreak;
 
 /**
  Inserts a string at the caret's position.
  
  @param text The string to be appended to the current text.
  */
-- (void)insertTextAtCaretRange:(NSString *)text;
+- (void)slk_insertTextAtCaretRange:(NSString *)text;
 
 /**
  Adds a string to a specific range.
@@ -56,7 +56,7 @@
  
  @return The range of the newly inserted text.
  */
-- (NSRange)insertText:(NSString *)text inRange:(NSRange)range;
+- (NSRange)slk_insertText:(NSString *)text inRange:(NSRange)range;
 
 /**
  Finds the word close to the caret's position, if any.
@@ -64,6 +64,6 @@
  @param range Returns the range of the found word.
  @returns The found word.
  */
-- (NSString *)wordAtCaretRange:(NSRangePointer)range;
+- (NSString *)slk_wordAtCaretRange:(NSRangePointer)range;
 
 @end

--- a/Source/Additions/UITextView+SLKAdditions.m
+++ b/Source/Additions/UITextView+SLKAdditions.m
@@ -18,12 +18,12 @@
 
 @implementation UITextView (SLKAdditions)
 
-- (NSUInteger)numberOfLines
+- (NSUInteger)slk_numberOfLines
 {
     return abs(self.contentSize.height/self.font.lineHeight);
 }
 
-- (void)scrollToCaretPositonAnimated:(BOOL)animated
+- (void)slk_scrollToCaretPositonAnimated:(BOOL)animated
 {
     if (!animated)
     {
@@ -41,7 +41,7 @@
     }
 }
 
-- (void)scrollToBottomAnimated:(BOOL)animated
+- (void)slk_scrollToBottomAnimated:(BOOL)animated
 {
     CGRect rect = [self caretRectForPosition:self.selectedTextRange.end];
     rect.size.height += self.textContainerInset.bottom;
@@ -62,9 +62,9 @@
     }
 }
 
-- (void)insertNewLineBreak
+- (void)slk_insertNewLineBreak
 {
-    [self insertTextAtCaretRange:@"\n"];
+    [self slk_insertTextAtCaretRange:@"\n"];
     
     BOOL animated = YES;
     SEL expandingSelector = NSSelectorFromString(@"isExpanding");
@@ -82,17 +82,17 @@
     
     //Detected break. Should scroll to bottom if needed.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.0025 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [self scrollToBottomAnimated:animated];
+        [self slk_scrollToBottomAnimated:animated];
     });
 }
 
-- (void)insertTextAtCaretRange:(NSString *)text
+- (void)slk_insertTextAtCaretRange:(NSString *)text
 {
-    NSRange range = [self insertText:text inRange:self.selectedRange];
+    NSRange range = [self slk_insertText:text inRange:self.selectedRange];
     self.selectedRange = NSMakeRange(range.location, 0);
 }
 
-- (NSRange)insertText:(NSString *)text inRange:(NSRange)range
+- (NSRange)slk_insertText:(NSString *)text inRange:(NSRange)range
 {
     // Skip if the text is empty
     if (text.length == 0) {
@@ -122,12 +122,12 @@
     return self.selectedRange;
 }
 
-- (NSString *)wordAtCaretRange:(NSRangePointer)range
+- (NSString *)slk_wordAtCaretRange:(NSRangePointer)range
 {
-    return [self wordAtRange:self.selectedRange rangeInText:range];
+    return [self slk_wordAtRange:self.selectedRange rangeInText:range];
 }
 
-- (NSString *)wordAtRange:(NSRange)range rangeInText:(NSRangePointer)rangePointer
+- (NSString *)slk_wordAtRange:(NSRange)range rangeInText:(NSRangePointer)rangePointer
 {
     NSString *text = self.text;
     NSInteger location = range.location;

--- a/Source/Additions/UIView+SLKAdditions.h
+++ b/Source/Additions/UIView+SLKAdditions.h
@@ -26,7 +26,7 @@
  @param options A mask of options indicating how you want to perform the animations.
  @param animations An additional block for custom animations.
  */
-- (void)animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations;
+- (void)slk_animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations;
 
 /**
  Animates the view's constraints by calling layoutIfNeeded.
@@ -36,7 +36,7 @@
  @param options A mask of options indicating how you want to perform the animations.
  @param animations An additional block for custom animations.
  */
-- (void)animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations;
+- (void)slk_animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations;
 
 /**
  Returns the view constraints matching a specific layout attribute (top, bottom, left, right, leading, trailing, etc.)
@@ -44,6 +44,6 @@
  @param attribute The layout attribute to use for searching.
  @return An array of matching constraints.
  */
-- (NSArray *)constraintsForAttribute:(NSLayoutAttribute)attribute;
+- (NSArray *)slk_constraintsForAttribute:(NSLayoutAttribute)attribute;
 
 @end

--- a/Source/Additions/UIView+SLKAdditions.m
+++ b/Source/Additions/UIView+SLKAdditions.m
@@ -20,13 +20,13 @@
 
 @implementation UIView (SLKAdditions)
 
-- (void)animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations
+- (void)slk_animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations
 {
     NSTimeInterval duration = bounce ? 0.5 : 0.2;
-    [self animateLayoutIfNeededWithDuration:duration bounce:bounce options:options animations:animations];
+    [self slk_animateLayoutIfNeededWithDuration:duration bounce:bounce options:options animations:animations];
 }
 
-- (void)animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations
+- (void)slk_animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations
 {
     if (bounce) {
         [UIView animateWithDuration:duration
@@ -58,7 +58,7 @@
     }
 }
 
-- (NSArray *)constraintsForAttribute:(NSLayoutAttribute)attribute
+- (NSArray *)slk_constraintsForAttribute:(NSLayoutAttribute)attribute
 {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"firstAttribute = %d", attribute];
     return [self.constraints filteredArrayUsingPredicate:predicate];

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -338,7 +338,7 @@ NSString * const SCKInputAccessoryViewKeyboardFrameDidChangeNotification = @"com
 {
     if ([text isEqualToString:@"\n"]) {
         //Detected break. Should insert new line break manually.
-        [textView insertNewLineBreak];
+        [textView slk_insertNewLineBreak];
         
         return NO;
     }
@@ -386,9 +386,9 @@ NSString * const SCKInputAccessoryViewKeyboardFrameDidChangeNotification = @"com
         
         BOOL bounces = self.controller.bounces && [self.textView isFirstResponder];
         
-        [self animateLayoutIfNeededWithBounce:bounces
-                                      options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionBeginFromCurrentState
-                                   animations:NULL];
+		[self slk_animateLayoutIfNeededWithBounce:bounces
+										  options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionBeginFromCurrentState
+									   animations:NULL];
     }
 }
 
@@ -423,19 +423,19 @@ NSString * const SCKInputAccessoryViewKeyboardFrameDidChangeNotification = @"com
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[accessoryView(0)]-(<=ver)-[textView(==minTextViewHeight@250)]-(==ver)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[accessoryView]|" options:0 metrics:metrics views:views]];
 
-    NSArray *heightConstraints = [self constraintsForAttribute:NSLayoutAttributeHeight];
-    NSArray *widthConstraints = [self constraintsForAttribute:NSLayoutAttributeWidth];
-    NSArray *bottomConstraints = [self constraintsForAttribute:NSLayoutAttributeBottom];
+    NSArray *heightConstraints = [self slk_constraintsForAttribute:NSLayoutAttributeHeight];
+    NSArray *widthConstraints = [self slk_constraintsForAttribute:NSLayoutAttributeWidth];
+    NSArray *bottomConstraints = [self slk_constraintsForAttribute:NSLayoutAttributeBottom];
 
     self.accessoryViewHC = heightConstraints[1];
 
     self.leftButtonWC = widthConstraints[0];
     self.leftButtonHC = heightConstraints[0];
-    self.leftMarginWC = [self constraintsForAttribute:NSLayoutAttributeLeading][0];
+    self.leftMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeLeading][0];
     self.bottomMarginWC = bottomConstraints[0];
 
     self.rightButtonWC = widthConstraints[1];
-    self.rightMarginWC = [self constraintsForAttribute:NSLayoutAttributeTrailing][0];
+    self.rightMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeTrailing][0];
 }
 
 - (void)updateConstraintConstants

--- a/Source/Classes/SLKTextView.m
+++ b/Source/Classes/SLKTextView.m
@@ -148,7 +148,7 @@ NSString * const SLKTextViewDidShakeNotification = @"com.slack.TextViewControlle
 
 - (BOOL)isExpanding
 {
-    if (self.numberOfLines >= self.maxNumberOfLines) {
+    if (self.slk_numberOfLines >= self.maxNumberOfLines) {
         return YES;
     }
     return NO;
@@ -206,7 +206,7 @@ NSString * const SLKTextViewDidShakeNotification = @"com.slack.TextViewControlle
         
         // Inserting the text fixes a UITextView bug whitch automatically scrolls to the bottom
         // and beyond scroll content size sometimes when the text is too long
-        [self insertTextAtCaretRange:item];
+        [self slk_insertTextAtCaretRange:item];
     }
 }
 
@@ -231,7 +231,7 @@ NSString * const SLKTextViewDidShakeNotification = @"com.slack.TextViewControlle
 
 - (void)flashScrollIndicatorsIfNeeded
 {
-    if (self.numberOfLines == self.maxNumberOfLines+1) {
+    if (self.slk_numberOfLines == self.maxNumberOfLines+1) {
         if (!_didFlashScrollIndicators) {
             _didFlashScrollIndicators = YES;
             [super flashScrollIndicators];

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -294,7 +294,7 @@
 {
     CGFloat height = [self deltaInputbarHeight];
     
-    height += roundf(self.textView.font.lineHeight*self.textView.numberOfLines);
+    height += roundf(self.textView.font.lineHeight*self.textView.slk_numberOfLines);
     height += (kTextViewVerticalPadding*2.0);
     
     return height;
@@ -304,10 +304,10 @@
 {
     CGFloat height = 0.0;
     
-    if (self.textView.numberOfLines == 1) {
+    if (self.textView.slk_numberOfLines == 1) {
         height = [self minimumInputbarHeight];
     }
-    else if (self.textView.numberOfLines < self.textView.maxNumberOfLines) {
+    else if (self.textView.slk_numberOfLines < self.textView.maxNumberOfLines) {
         height += [self currentInputbarHeight];
     }
     else {
@@ -509,13 +509,13 @@
             
             BOOL bounces = self.bounces && [self.textView isFirstResponder];
             
-            [self.view animateLayoutIfNeededWithBounce:bounces
-                                                 options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
-                                            animations:^{
-                                                if (self.isEditing) {
-                                                    [self.textView scrollToCaretPositonAnimated:NO];
-                                                }
-                                            }];
+			[self.view slk_animateLayoutIfNeededWithBounce:bounces
+												   options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
+												animations:^{
+													if (self.isEditing) {
+														[self.textView slk_scrollToCaretPositonAnimated:NO];
+													}
+												}];
         }
         else {
             [self.view layoutIfNeeded];
@@ -567,7 +567,7 @@
     }
     
     // Don't show if the content offset is not at top (when inverted) or at bottom (when not inverted)
-    if ((self.isInverted && ![self.scrollViewProxy isAtTop]) || (!self.isInverted && ![self.scrollViewProxy isAtBottom])) {
+    if ((self.isInverted && ![self.scrollViewProxy slk_isAtTop]) || (!self.isInverted && ![self.scrollViewProxy slk_isAtBottom])) {
         return NO;
     }
     
@@ -655,7 +655,7 @@
     }
 
     [self.textView setText:text];
-    [self.textView scrollToCaretPositonAnimated:YES];
+    [self.textView slk_scrollToCaretPositonAnimated:YES];
     
     // Updates the constraints after inserting text, if already first responder
     if ([self.textView isFirstResponder]) {
@@ -678,7 +678,7 @@
 
 - (void)insertNewLineBreak
 {
-    [self.textView insertNewLineBreak];
+    [self.textView slk_insertNewLineBreak];
 }
 
 - (void)prepareForInterfaceRotation
@@ -686,10 +686,10 @@
     [self.view layoutIfNeeded];
     
     if ([self.textView isFirstResponder]) {
-        [self.textView scrollToCaretPositonAnimated:NO];
+        [self.textView slk_scrollToCaretPositonAnimated:NO];
     }
     else {
-        [self.textView scrollToBottomAnimated:NO];
+        [self.textView slk_scrollToBottomAnimated:NO];
     }
 }
 
@@ -720,7 +720,7 @@
     BOOL show = [notification.name isEqualToString:UIKeyboardWillShowNotification];
     
     // Programatically stops scrolling before updating the view constraints (to avoid scrolling glitch)
-    [self.scrollViewProxy stopScrolling];
+    [self.scrollViewProxy slk_stopScrolling];
     
     // Updates the height constraints' constants
     self.keyboardHC.constant = [self appropriateKeyboardHeight:notification];
@@ -731,10 +731,10 @@
     }
     
     // Only for this animation, we set bo to bounce since we want to give the impression that the text input is glued to the keyboard.
-    [self.view animateLayoutIfNeededWithDuration:duration
-                                          bounce:NO
-                                         options:(curve<<16)|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
-                                      animations:NULL];
+	[self.view slk_animateLayoutIfNeededWithDuration:duration
+											  bounce:NO
+											 options:(curve<<16)|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
+										  animations:NULL];
 }
 
 - (void)didShowOrHideKeyboard:(NSNotification *)notification
@@ -830,9 +830,9 @@
     self.typingIndicatorViewHC.constant = indicatorView.isVisible ?  0.0 : indicatorView.height;
     self.scrollViewHC.constant -= self.typingIndicatorViewHC.constant;
     
-    [self.view animateLayoutIfNeededWithBounce:self.bounces
-                               options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
-                          animations:NULL];
+	[self.view slk_animateLayoutIfNeededWithBounce:self.bounces
+										   options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
+										animations:NULL];
 }
 
 - (void)didChangeTextViewContentSize:(NSNotification *)notification
@@ -925,7 +925,7 @@
     }
 
     NSRange range;
-    NSString *word = [self.textView wordAtCaretRange:&range];
+    NSString *word = [self.textView slk_wordAtCaretRange:&range];
     
     for (NSString *sign in self.registeredPrefixes) {
         
@@ -997,13 +997,13 @@
     SLKTextView *textView = self.textView;
     
     NSRange range = NSMakeRange(self.foundPrefixRange.location+1, self.foundWord.length);
-    NSRange insertionRange = [textView insertText:string inRange:range];
+    NSRange insertionRange = [textView slk_insertText:string inRange:range];
     
     textView.selectedRange = NSMakeRange(insertionRange.location, 0);
     
     [self cancelAutoCompletion];
     
-    [textView scrollToCaretPositonAnimated:NO];
+    [textView slk_scrollToCaretPositonAnimated:NO];
 }
 
 - (void)hideautoCompletionView
@@ -1041,9 +1041,9 @@
     
     self.autoCompletionViewHC.constant = viewHeight;
     
-    [self.view animateLayoutIfNeededWithBounce:self.bounces
-                                         options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
-                                    animations:NULL];
+	[self.view slk_animateLayoutIfNeededWithBounce:self.bounces
+										   options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
+										animations:NULL];
 }
 
 
@@ -1121,8 +1121,8 @@
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[typingIndicatorView]|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[textInputbar]|" options:0 metrics:nil views:views]];
 
-    NSArray *bottomConstraints = [self.view constraintsForAttribute:NSLayoutAttributeBottom];
-    NSArray *heightConstraints = [self.view constraintsForAttribute:NSLayoutAttributeHeight];
+    NSArray *bottomConstraints = [self.view slk_constraintsForAttribute:NSLayoutAttributeBottom];
+    NSArray *heightConstraints = [self.view slk_constraintsForAttribute:NSLayoutAttributeHeight];
     
     self.scrollViewHC = heightConstraints[0];
     self.autoCompletionViewHC = heightConstraints[1];


### PR DESCRIPTION
Class extensions (aka categories) provided by libraries should always prefix their property and method names.
- Unprefixed methods and properties can collide with other libraries and cause weird behavior or crashes (usually causes a compiler warning).
- Unprefixed methods and properties can even collide with private iOS API causing weird behavior or crashes at runtime without prior warning.

In this project there was a conflict with the private iOS method [`-[NSObject safeValueForKey:]`](https://github.com/EthanArbuckle/IOS-7-Headers/blob/master/PrivateFrameworks/AccessibilityUtilities.framework/NSObject-UIAccessibilitySafeCategory.h). It was overwritten by `UIScrollView (SLKAdditions)`. iOS called this method instead of its own implementation which caused an unbalanced retain/release count leading to a crash.
