### PR TITLE
- Stops scrollViewHC from being calculated a second time in iOS 7

### DIFF
--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -620,12 +620,7 @@ NSString * const SCKInputAccessoryViewKeyboardFrameDidChangeNotification = @"com
 
 - (NSString *)keyPathForKeyboardHandling
 {
-    if (UI_IS_IOS8_AND_HIGHER) {
-        return NSStringFromSelector(@selector(center));
-    }
-    else {
-        return NSStringFromSelector(@selector(frame));
-    }
+    return NSStringFromSelector(@selector(center));
 }
 
 - (void)willMoveToSuperview:(UIView *)newSuperview


### PR DESCRIPTION
A proposed fix for Issue #10 :The textview's top will still change when hardware keyboard is connected.
