### PR TITLE
Added keyboard trigger offset

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -904,7 +904,7 @@
     
     // Skips this if it's not the expected textView.
     // Checking the keyboard height constant helps to disable the view constraints update on iPad when the keyboard is undocked.
-    if (![self.textView isFirstResponder] || self.keyboardHC.constant == 0) {
+    if (![self.textView isFirstResponder] || (self.keyboardHC.constant == 0 && self.keyboardStatus == SLKKeyboardStatusDidHide)) {
         return;
     }
     


### PR DESCRIPTION
Updated the inputAccessoryView to include the height of the textInputbar. This is the simplest solution, other solutions require too much hacking and maintenance. There is a slight delay on the keyboardWillShow animation since it includes the inputAccessoryView height in the keyboard notification.
