### PR TITLE
Fixed counter formatting & 64-bit warning

### DIFF
--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -377,13 +377,13 @@ NSString * const SLKInputAccessoryViewKeyboardFrameDidChangeNotification = @"com
     NSString *counter = nil;
     
     if (self.counterStyle == SLKCounterStyleNone) {
-        counter = [NSString stringWithFormat:@"%ld", (unsigned long)text.length];
+        counter = [NSString stringWithFormat:@"%lu", (unsigned long)text.length];
     }
     if (self.counterStyle == SLKCounterStyleSplit) {
-        counter = [NSString stringWithFormat:@"%ld/%ld", (unsigned long)text.length, (unsigned long)self.maxCharCount];
+        counter = [NSString stringWithFormat:@"%lu/%lu", (unsigned long)text.length, (unsigned long)self.maxCharCount];
     }
     if (self.counterStyle == SLKCounterStyleCountdown) {
-        counter = [NSString stringWithFormat:@"%lu", text.length-self.maxCharCount];
+        counter = [NSString stringWithFormat:@"%ld", (long)(text.length - self.maxCharCount)];
     }
     
     self.charCountLabel.text = counter;


### PR DESCRIPTION
- `unsigned long` should use `%lu`
- `long` should use `%ld`
- added missing `long` cast to fix potential bug on 64-bit OS (also causing compiler warning)
