### PR TITLE
Fixed that initial values were not set for SLKTextInputbar constraint constants.

### DIFF
--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -73,7 +73,8 @@ NSString * const SLKInputAccessoryViewKeyboardFrameDidChangeNotification = @"com
     [self addSubview:self.charCountLabel];
 
     [self setupViewConstraints];
-    
+    [self updateConstraintConstants];
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didChangeTextView:) name:UITextViewTextDidChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didChangeTextViewContentSize:) name:SLKTextViewContentSizeDidChangeNotification object:nil];
     


### PR DESCRIPTION
There was an additional padding of 8 points left to the text view until some text was entered, when the text view suddenly jumps to the left by these 8 points.

Only happens if there is no left button because `updateConstraintConstants` was never called to ensure correct initial values.
