### PR TITLE
Remove circular dependency from Podspec

### DIFF
--- a/SlackTextViewController.podspec
+++ b/SlackTextViewController.podspec
@@ -18,8 +18,6 @@ Pod::Spec.new do |s|
   s.source_files 		= "Classes", "Source/Classes/*.{h,m}"
   s.frameworks   		= 'UIKit'
 
-  s.dependency     		'SlackTextViewController/Additions'
-
   s.subspec 'Additions' do |add|
     add.source_files     = 'Source/Additions/*.{h,m}'
   end


### PR DESCRIPTION
Part of the latest pre-release version of CocoaPods is a new dependency manager that isn't capable of handling circular dependencies in Podspecs. As a result, trying to install SlackTextViewController via the CocoaPods 0.35 RC results in an error. (see https://github.com/CocoaPods/CocoaPods/issues/2732)

This seems to fix the SlackTextViewController pod for me, at least when installing it with my Podfile pointed to my fork's git repo. A pod spec inherits all of its subspecs by default (see the [Podfile docs](http://guides.cocoapods.org/syntax/podspec.html#subspec)), so explicitly listing the subspec as a dependency isn't necessary.

Cheers!
