### PR TITLE
Update path to file templates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,6 @@ There are 3 examples for illustrating the programatic, storyboard and Swift appr
 We have prepared a set of useful XCode templates so you can quickly start using SlackTextViewController.
 
 To install them, open up your terminal and type:
-```sh ./SlackTextViewController/Template/install.sh```
+```sh ./SlackTextViewController/File\ Templates/install.sh```
 
 These templates are also available in [Alcatraz](https://github.com/supermarin/Alcatraz).


### PR DESCRIPTION
It looks like on October 1st https://github.com/slackhq/SlackTextViewController/commit/f729fd9a1ea4ddd6f3e600dbb49c5dd36cdf2969 was the initial addition of the Xcode templates info to the README, and on October 7th https://github.com/slackhq/SlackTextViewController/commit/05d8a69e78042c8b33a186f66493d7cee90b14ff renamed the templates folder without fixing the accompanying reference.
