### PR TITLE
Removed dead code in SLKTextViewController

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -971,10 +971,6 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
     else {
         return NO;
     }
-    
-    if (CGRectIsNull(keyboardFrame)) {
-        return NO;
-    }
 }
 
 - (void)reloadInputAccessoryViewIfNeeded


### PR DESCRIPTION
Fixes compiler warning "Code will never be executed"
