### PR TITLE
fixed not building storyboard related target, support for transformations of left/right buttons on iOS 7

### DIFF
--- a/Examples/Messenger/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger/Messenger-Shared/MessageViewController.m
@@ -81,7 +81,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 
     [self.leftButton setImage:[UIImage imageNamed:@"icn_upload"] forState:UIControlStateNormal];
     [self.leftButton setTintColor:[UIColor grayColor]];
-    
+
     [self.rightButton setTitle:NSLocalizedString(@"Send", nil) forState:UIControlStateNormal];
     
     [self.textInputbar.editorTitle setTextColor:[UIColor darkGrayColor]];
@@ -194,10 +194,12 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     [super textDidUpdate:animated];
 }
 
-- (void)didPressLeftButton:(id)sender
+- (void)didPressLeftButton:(UIButton *)sender
 {
     // Notifies the view controller when the left button's action has been triggered, manually.
-    
+	sender.superview.layer.transform = sender.tag? CATransform3DIdentity : CATransform3DMakeRotation(M_PI_4, 0, 0, 1);
+	sender.tag = 1 - sender.tag;
+	
     [super didPressLeftButton:sender];
 }
 

--- a/Examples/Messenger/Messenger-Storyboard/Base.lproj/Main.storyboard
+++ b/Examples/Messenger/Messenger-Storyboard/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="0WO-Kt-Oxc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="nJp-d0-Z0H">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <scenes>
         <!--Message View Controller-->
@@ -18,29 +18,47 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
-                    <navigationItem key="navigationItem" id="nZY-L4-a9K"/>
+                    <navigationItem key="navigationItem" id="nZY-L4-a9K">
+                        <barButtonItem key="leftBarButtonItem" title="Push" id="IgL-2u-f6X">
+                            <connections>
+                                <segue destination="Q05-Yp-wrT" kind="show" id="1lu-xU-yZt"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1302" y="492"/>
         </scene>
-        <!--Tab Bar Controller-->
-        <scene sceneID="SEt-8k-R87">
+        <!--View Controller-->
+        <scene sceneID="B1d-60-9iX">
             <objects>
-                <tabBarController id="0WO-Kt-Oxc" sceneMemberID="viewController">
-                    <nil key="simulatedBottomBarMetrics"/>
-                    <tabBar key="tabBar" contentMode="scaleToFill" id="US0-fN-o9u">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    </tabBar>
-                    <connections>
-                        <segue destination="nJp-d0-Z0H" kind="relationship" relationship="viewControllers" id="nd7-Np-oUR"/>
-                    </connections>
-                </tabBarController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="bQn-nb-Tgr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <viewController id="Q05-Yp-wrT" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="q4X-s1-Mso"/>
+                        <viewControllerLayoutGuide type="bottom" id="so9-VV-wxw"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Uhy-UX-9MX">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Children View Controller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6M-36-Uob">
+                                <rect key="frame" x="208" y="289" width="185" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="centerY" secondItem="n6M-36-Uob" secondAttribute="centerY" id="Rpa-Hr-sJU"/>
+                            <constraint firstAttribute="centerX" secondItem="n6M-36-Uob" secondAttribute="centerX" id="qOt-AR-sHq"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="egJ-xr-CF8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-132" y="492"/>
+            <point key="canvasLocation" x="1969" y="492"/>
         </scene>
         <!--Tab-->
         <scene sceneID="5B4-6e-pdF">

--- a/Examples/Messenger/Messenger.xcodeproj/project.pbxproj
+++ b/Examples/Messenger/Messenger.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13E6388D1A7E537E00FB6C32 /* MessageTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7C6BA41A6E208E006E3FAB /* MessageTextView.m */; };
 		35A4C7C11DE3FD17F022DC0C /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFA9095EABC480682E6396C /* libPods.a */; };
 		4A8EFBBFAC0F49199AAABF46 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFA9095EABC480682E6396C /* libPods.a */; };
 		4F3EDB4D199ED00F004C15D6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F3EDB4C199ED00F004C15D6 /* Foundation.framework */; };
@@ -517,6 +518,7 @@
 				4F8ADA781A68C37400023752 /* Message.m in Sources */,
 				4F86BF6D19F011D0007A3D4A /* AppDelegate.m in Sources */,
 				4F86BF6A19F011D0007A3D4A /* main.m in Sources */,
+				13E6388D1A7E537E00FB6C32 /* MessageTextView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -74,7 +74,7 @@
 
     [self addSubview:self.editorContentView];
     [self addSubview:[self makeContainerForControl:self.leftButton]];
-    [self addSubview:[self makeContainerForControl:self.rightButton]];
+    [self addSubview:self.rightButton];
     [self addSubview:self.textView];
     [self addSubview:self.charCountLabel];
 
@@ -514,7 +514,7 @@
 
     NSDictionary *views = @{@"textView": self.textView,
                             @"leftButton": self.leftButton.superview,
-                            @"rightButton": self.rightButton.superview,
+                            @"rightButton": self.rightButton,
                             @"contentView": self.editorContentView,
                             @"charCountLabel": self.charCountLabel
                             };
@@ -528,7 +528,7 @@
                               @"minTextViewHeight" : @(self.textView.intrinsicContentSize.height),
                               };
 
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton]-(<=left)-[textView]-(right)-[rightButton]-(right)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton]-(<=left)-[textView]-(right)-[rightButton(0)]-(right)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton]-(0@750)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=rightVerMargin)-[rightButton]-(<=rightVerMargin)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(<=top)-[charCountLabel]-(>=0)-|" options:0 metrics:metrics views:views]];
@@ -545,7 +545,7 @@
     self.leftMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeLeading][0];
     self.bottomMarginWC = [self slk_constraintForAttribute:NSLayoutAttributeBottom firstItem:self secondItem:self.leftButton.superview];
 
-    self.rightButtonWC = [self.rightButton.superview slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.rightButton secondItem:nil];
+    self.rightButtonWC = [self slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.rightButton secondItem:nil];
     self.rightMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeTrailing][0];
 }
 

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -73,8 +73,8 @@
     self.contentInset = UIEdgeInsetsMake(5.0, 8.0, 5.0, 8.0);
 
     [self addSubview:self.editorContentView];
-    [self addSubview:self.leftButton];
-    [self addSubview:self.rightButton];
+    [self addSubview:[self makeContainerForControl:self.leftButton]];
+    [self addSubview:[self makeContainerForControl:self.rightButton]];
     [self addSubview:self.textView];
     [self addSubview:self.charCountLabel];
 
@@ -85,6 +85,22 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didChangeTextViewContentSize:) name:SLKTextViewContentSizeDidChangeNotification object:nil];
     
     [self.leftButton.imageView addObserver:self forKeyPath:NSStringFromSelector(@selector(image)) options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL];
+}
+
+
+#pragma mark - Helpers
+
+- (UIView *)makeContainerForControl:(UIView *)control
+{
+	UIView *result = [[UIView alloc] init];
+	[result addSubview:control];
+	result.translatesAutoresizingMaskIntoConstraints = NO;
+	
+	NSDictionary *views = NSDictionaryOfVariableBindings(control);
+	[result addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(0)-[control(0)]-(0)-|" options:0 metrics:nil views:views]];
+	[result addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(0)-[control(0)]-(0)-|" options:0 metrics:nil views:views]];
+	
+	return result;
 }
 
 
@@ -497,8 +513,8 @@
     CGFloat rightVerMargin = (self.intrinsicContentSize.height - CGRectGetHeight(self.rightButton.frame)) / 2.0;
 
     NSDictionary *views = @{@"textView": self.textView,
-                            @"leftButton": self.leftButton,
-                            @"rightButton": self.rightButton,
+                            @"leftButton": self.leftButton.superview,
+                            @"rightButton": self.rightButton.superview,
                             @"contentView": self.editorContentView,
                             @"charCountLabel": self.charCountLabel
                             };
@@ -512,8 +528,8 @@
                               @"minTextViewHeight" : @(self.textView.intrinsicContentSize.height),
                               };
 
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton(0)]-(<=left)-[textView]-(right)-[rightButton(0)]-(right)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton(0)]-(0@750)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton]-(<=left)-[textView]-(right)-[rightButton]-(right)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton]-(0@750)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=rightVerMargin)-[rightButton]-(<=rightVerMargin)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(<=top)-[charCountLabel]-(>=0)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left@250)-[charCountLabel(<=50@1000)]-(right@750)-|" options:0 metrics:metrics views:views]];
@@ -523,13 +539,13 @@
     
     self.editorContentViewHC = [self slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.editorContentView secondItem:nil];
     
-    self.leftButtonWC = [self slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.leftButton secondItem:nil];
-    self.leftButtonHC = [self slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.leftButton secondItem:nil];
+    self.leftButtonWC = [self.leftButton.superview slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.leftButton secondItem:nil];
+    self.leftButtonHC = [self.leftButton.superview slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.leftButton secondItem:nil];
     
     self.leftMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeLeading][0];
-    self.bottomMarginWC = [self slk_constraintForAttribute:NSLayoutAttributeBottom firstItem:self secondItem:self.leftButton];
+    self.bottomMarginWC = [self slk_constraintForAttribute:NSLayoutAttributeBottom firstItem:self secondItem:self.leftButton.superview];
 
-    self.rightButtonWC = [self slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.rightButton secondItem:nil];
+    self.rightButtonWC = [self.rightButton.superview slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.rightButton secondItem:nil];
     self.rightMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeTrailing][0];
 }
 


### PR DESCRIPTION
1) fixed not building storyboard related target
This target has failed to build, some files was removed from it

2) transformation support
In auto layout environment (specifically on iOS 7) application cannot handle layer transformations correctly for a view that is backed up by constraints. The workaround is having separate container view that aligns inner views using desired constraints. In this case applying custom transform matrixes to this container produces expected results.