### PR TITLE
Correct Image Height and Optional ability to media without text

### DIFF
--- a/Examples/Messenger/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Messenger/Pods/Pods.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		8F5BA9F9A9F63765DF7557C3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC63CBC9F24B7ED7A971F799 /* Foundation.framework */; };
 		A1474BD275A5738DE678B2CB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC63CBC9F24B7ED7A971F799 /* Foundation.framework */; };
 		B2D4D6316C72F373C34FFA68 /* SLKTypingIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = CD1809A1AA52E4893C5B4354 /* SLKTypingIndicatorView.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		BD8C8AED1A89FBEF003B683F /* SLKTextView+Attachments.m in Sources */ = {isa = PBXBuildFile; fileRef = BD8C8AEC1A89FBEF003B683F /* SLKTextView+Attachments.m */; };
 		C67BF7584A83FBDE5ACD1853 /* SLKUIConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E64BB6B4EA5BD7B64F79133A /* SLKUIConstants.h */; };
 		CBE8401BC93B584AE64C65F2 /* UIScrollView+SLKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E7F80DC69440D5A05CFCEF2 /* UIScrollView+SLKAdditions.h */; };
 		D5870E78EC10E1D0C8C869AF /* UIScrollView+SLKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DD10209C67C0570F212053B3 /* UIScrollView+SLKAdditions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -83,6 +84,8 @@
 		B58DB8F386A9916306EC4643 /* SLKInputAccessoryView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKInputAccessoryView.h; path = Source/Classes/SLKInputAccessoryView.h; sourceTree = "<group>"; };
 		BB76D79F6CA293113845DAF6 /* LoremIpsum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LoremIpsum.h; path = LoremIpsum/LoremIpsum.h; sourceTree = "<group>"; };
 		BC63CBC9F24B7ED7A971F799 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		BD8C8AEB1A89FBEF003B683F /* SLKTextView+Attachments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SLKTextView+Attachments.h"; path = "Source/Classes/SLKTextView+Attachments.h"; sourceTree = "<group>"; };
+		BD8C8AEC1A89FBEF003B683F /* SLKTextView+Attachments.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SLKTextView+Attachments.m"; path = "Source/Classes/SLKTextView+Attachments.m"; sourceTree = "<group>"; };
 		CD1809A1AA52E4893C5B4354 /* SLKTypingIndicatorView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SLKTypingIndicatorView.m; path = Source/Classes/SLKTypingIndicatorView.m; sourceTree = "<group>"; };
 		D24A3A93BF66BC097ECF3A5C /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
 		D6D645D36CB11DAD0636F2A3 /* UIView+SLKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+SLKAdditions.m"; path = "Source/Additions/UIView+SLKAdditions.m"; sourceTree = "<group>"; };
@@ -190,6 +193,8 @@
 				DD10209C67C0570F212053B3 /* UIScrollView+SLKAdditions.m */,
 				7254A2F2DAFFA0219293AB10 /* UIView+SLKAdditions.h */,
 				D6D645D36CB11DAD0636F2A3 /* UIView+SLKAdditions.m */,
+				BD8C8AEB1A89FBEF003B683F /* SLKTextView+Attachments.h */,
+				BD8C8AEC1A89FBEF003B683F /* SLKTextView+Attachments.m */,
 			);
 			name = Additions;
 			sourceTree = "<group>";
@@ -383,6 +388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BDC6542829D33831A1FF842 /* Pods-dummy.m in Sources */,
+				BD8C8AED1A89FBEF003B683F /* SLKTextView+Attachments.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Classes/SLKTextInputbar.h
+++ b/Source/Classes/SLKTextInputbar.h
@@ -48,6 +48,9 @@ typedef NS_ENUM(NSUInteger, SLKCounterStyle) {
 /** YES if the right button should be hidden animatedly in case the text view has no text in it. Default is YES. */
 @property (nonatomic, readwrite) BOOL autoHideRightButton;
 
+//** Enable right button when NSAttributedString contains a NSTextAttachment. Default is NO. */
+@property (nonatomic, readwrite) BOOL enableRightButtonWithAttachment;
+
 /** The inner padding to use when laying out content in the view. Default is {5, 8, 5, 8}. */
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -20,6 +20,7 @@
 #import "SLKTextView+SLKAdditions.h"
 #import "SLKUIConstants.h"
 #import "UIView+SLKAdditions.h"
+#import "SLKTextView+Attachments.h"
 
 @interface SLKTextInputbar ()
 
@@ -69,6 +70,7 @@
 - (void)_commonInit
 {
     self.autoHideRightButton = YES;
+    self.enableRightButtonWithAttachment = NO;
     self.editorContentViewHeight = 38.0;
     self.contentInset = UIEdgeInsetsMake(5.0, 8.0, 5.0, 8.0);
 
@@ -262,24 +264,32 @@
 {
     NSString *title = [self.rightButton titleForState:UIControlStateNormal];
     CGSize rigthButtonSize = [title sizeWithAttributes:@{NSFontAttributeName: self.rightButton.titleLabel.font}];
-    
     if (self.autoHideRightButton) {
-        if (self.textView.text.length == 0) {
+        if ([self shouldHideRightButton]) {
             return 0.0;
         }
     }
+    
     return rigthButtonSize.width+self.contentInset.right;
 }
 
-- (CGFloat)_appropriateRightButtonMargin
-{
+- (CGFloat)_appropriateRightButtonMargin {
     if (self.autoHideRightButton) {
-        if (self.textView.text.length == 0) {
+        if ([self shouldHideRightButton]) {
             return 0.0;
         }
     }
     
     return self.contentInset.right;
+}
+
+- (BOOL)shouldHideRightButton {
+    if((!self.enableRightButtonWithAttachment && [self.textView slk_hasImageAttachment] && self.textView.text.length == 1)
+       || ![self.textView.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length) {
+        return YES;
+    }
+    
+    return NO;
 }
 
 - (BOOL)isViewVisible
@@ -439,7 +449,7 @@
     SLKTextView *textView = (SLKTextView *)notification.object;
     
     // Skips this it's not the expected textView.
-    if (![textView isEqual:self.textView]) {
+    if (![textView isEqual:self.textView] && ![self.textView isFirstResponder]) {
         return;
     }
     

--- a/Source/Classes/SLKTextView+Attachments.h
+++ b/Source/Classes/SLKTextView+Attachments.h
@@ -1,0 +1,16 @@
+//
+//  SLKTextView+Attachments.h
+//  Pods
+//
+//  Created by KattMing on 2/9/15.
+//
+//
+
+#import "SLKTextView.h"
+
+@interface SLKTextView (Attachments)
+
+- (void)slk_insertImage:(UIImage *)image roundedCorners:(BOOL)roundedCorners;
+- (BOOL)slk_hasImageAttachment;
+
+@end

--- a/Source/Classes/SLKTextView+Attachments.m
+++ b/Source/Classes/SLKTextView+Attachments.m
@@ -1,0 +1,70 @@
+//
+//  SLKTextView+Attachments.m
+//  Pods
+//
+//  Created by KattMing on 2/9/15.
+//
+//
+
+#import "SLKTextView+Attachments.h"
+
+@implementation SLKTextView (Attachments)
+
+//Thanks @Saurman
+- (void)slk_insertImage:(UIImage *)image roundedCorners:(BOOL)roundedCorners {
+    NSMutableAttributedString *attributedString = [self.attributedText mutableCopy];
+    
+    // find image if its already there and remove it
+    [attributedString enumerateAttributesInRange:(NSMakeRange(0, attributedString.length)) options:0 usingBlock:^(NSDictionary *attrs, NSRange range, BOOL *stop) {
+        id attachment = [attrs objectForKey:NSAttachmentAttributeName];
+        if ( attachment && [attachment isKindOfClass:[NSTextAttachment class]] ) {
+            [attributedString deleteCharactersInRange:range];
+            *stop = YES;
+        }
+    }];
+    
+    
+    NSTextAttachment *textAttachment = [[NSTextAttachment alloc] init];
+    textAttachment.image = [self imageWithImage:image roundedCorners:roundedCorners];
+    NSAttributedString *attrStringWithImage = [NSAttributedString attributedStringWithAttachment:textAttachment];
+    [attributedString insertAttributedString:attrStringWithImage atIndex:0];
+    self.attributedText = attributedString;
+    [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:nil];
+}
+
+- (BOOL)slk_hasImageAttachment {
+    __block BOOL result = NO;
+    [self.attributedText enumerateAttributesInRange:(NSMakeRange(0, self.attributedText.length)) options:0 usingBlock:^(NSDictionary *attrs, NSRange range, BOOL *stop) {
+        id attachment = [attrs objectForKey:NSAttachmentAttributeName];
+        if ( attachment && [attachment isKindOfClass:[NSTextAttachment class]] ) {
+            result = YES;
+            *stop = YES;
+        }
+    }];
+    
+    return result;
+}
+
+- (UIImage*)imageWithImage:(UIImage*)image roundedCorners:(BOOL)roundedCorners {
+    CGFloat oldWidth = image.size.width;
+    CGFloat scaleFactor = oldWidth / (CGRectGetWidth(self.frame)/4);
+    image = [UIImage imageWithCGImage:image.CGImage scale:scaleFactor orientation:UIImageOrientationUp];
+    
+    return roundedCorners ? [self makeRoundCornersWithRadius:5.0 inputImage:image] : image;
+}
+
+-(UIImage*)makeRoundCornersWithRadius:(const CGFloat)RADIUS inputImage:(UIImage *)inputImage {
+    UIImage *image = inputImage;
+    // Begin a new image that will be the new image with the rounded corners
+    UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
+    const CGRect RECT = CGRectMake(0, 0, image.size.width, image.size.height);
+    [[UIBezierPath bezierPathWithRoundedRect:RECT cornerRadius:RADIUS] addClip];
+    [image drawInRect:RECT];
+    
+    UIImage *imageNew = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return imageNew;
+}
+
+@end

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -17,6 +17,7 @@
 #import "SLKTextViewController.h"
 #import "SLKInputAccessoryView.h"
 #import "SLKUIConstants.h"
+#import "SLKTextView+Attachments.h"
 
 NSString * const SLKKeyboardWillShowNotification =  @"SLKKeyboardWillShowNotification";
 NSString * const SLKKeyboardDidShowNotification =   @"SLKKeyboardDidShowNotification";
@@ -393,25 +394,19 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
     return height;
 }
 
-- (CGFloat)_appropriateInputbarHeight
-{
-    CGFloat height = 0.0;
+- (CGFloat)_appropriateInputbarHeight {
+    BOOL hasImage = [self.textView slk_hasImageAttachment];
+    CGFloat maximumHeight = [self _inputBarHeightForLines:self.textView.maxNumberOfLines];
     CGFloat minimumHeight = [self _minimumInputbarHeight];
     
-    if (self.textView.numberOfLines == 1) {
-        height = minimumHeight;
-    }
-    else if (self.textView.numberOfLines < self.textView.maxNumberOfLines) {
-        height = [self _inputBarHeightForLines:self.textView.numberOfLines];
-    }
-    else {
-        height = [self _inputBarHeightForLines:self.textView.maxNumberOfLines];
-    }
+    CGRect textRect = [self.textView.attributedText boundingRectWithSize:CGSizeMake(CGRectGetWidth(self.textView.frame), INT16_MAX)
+                                                                 options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
+                                                                 context:nil];
     
-    
-    if (height < minimumHeight) {
-        height = minimumHeight;
-    }
+    const int extraPadding = hasImage? 10 : 0;
+    CGFloat height = self.textInputbar.contentInset.top + self.textInputbar.contentInset.bottom + textRect.size.height;
+    height = MIN(MAX(height + extraPadding * 2, minimumHeight), maximumHeight);
+    return roundf(height);
     
     if (self.isEditing) {
         height += self.textInputbar.editorContentViewHeight;


### PR DESCRIPTION
I (and also Saurman) noticed that TextView calculations were incorrect when a NSTextAttachment was inserted into the attributed string. I took a look at Saurman's code he pasted and used that and also some of my own to add a clean implementation of pasting a photo. I also added adding photos from camera and library using the left button, but left it out for this PR since it was a bit overkill. This PR also added the ability to "send" an attachment without text while autoHideRightButton == true.