### PR TITLE
Extend SLKTextViewController to support arbitrary scroll views

### DIFF
--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -48,6 +48,9 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /** The main collection view managed by the controller object. Not nil if the controller is initialised with -initWithCollectionViewLayout: */
 @property (nonatomic, readonly) UICollectionView *collectionView;
 
+/** The main scroll view view managed by the controller object. Not nil if the controller is initialised with -initWithScrollView: */
+@property (nonatomic, readonly) UIScrollView *scrollView;
+
 /** The bottom toolbar containing a text view and buttons. */
 @property (nonatomic, readonly) SLKTextInputbar *textInputbar;
 
@@ -122,6 +125,15 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  @return An initialized SLKTextViewController object or nil if the object could not be created.
  */
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_DESIGNATED_INITIALIZER;
+
+/**
+ Initializes a text view controller to manage an arbitraty scroll view. The caller is responsible for configuration 
+ of the scroll view, including wiring the delegate.
+
+ @param a UISCrollView to be used as the main content area.
+ @return An initialized SLKTextViewController object or nil if the object could not be created.
+ */
+- (instancetype)initWithScrollView:(UIScrollView *)scrollView NS_DESIGNATED_INITIALIZER;
 
 /**
  Initializes either a table or collection view controller.

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -68,6 +68,7 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
 @implementation SLKTextViewController
 @synthesize tableView = _tableView;
 @synthesize collectionView = _collectionView;
+@synthesize scrollView = _scrollView;
 @synthesize typingIndicatorView = _typingIndicatorView;
 @synthesize textInputbar = _textInputbar;
 @synthesize autoCompletionView = _autoCompletionView;
@@ -106,6 +107,24 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
     if (self = [super initWithNibName:nil bundle:nil])
     {
         self.scrollViewProxy = [self collectionViewWithLayout:layout];
+        [self _commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithScrollView:(UIScrollView *)scrollView
+{
+    NSAssert([self class] != [SLKTextViewController class], @"Oops! You must subclass SLKTextViewController.");
+
+    if (self = [super initWithNibName:nil bundle:nil])
+    {
+        _scrollView = scrollView;
+
+        _scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+        _scrollView.backgroundColor = [UIColor whiteColor];
+        _scrollView.scrollsToTop = YES;
+
+        self.scrollViewProxy = _scrollView;
         [self _commonInit];
     }
     return self;
@@ -1943,6 +1962,8 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
     _collectionView.delegate = nil;
     _collectionView.dataSource = nil;
     _collectionView = nil;
+
+    _scrollView = nil;
     
     _autoCompletionView.delegate = nil;
     _autoCompletionView.dataSource = nil;


### PR DESCRIPTION
This PR adds a constructor that takes an existing `UIScrollView` and uses it as the main content view. This allows using arbitrary classes to display your content, not just `UITableView` or `UICollectionView`. My motivation for this was to enable the use of `ASScrollView` from Facebook's [AsyncDisplayKit](http://asyncdisplaykit.org/). This method works well for that purpose and I'm sure has other uses as well. In order to make it as flexible as possible, it does very little with the UIScrollView that isn't absolutely necessary. (It doesn't wire up the delegate which actually might make sense generally speaking, but `ASScrollView` doesn't allow that.)

What I've done here has a minimum impact on the codebase, but I also tried a version that basically makes `scollViewProxy` a strong reference and `tableView`/`collectionView` just reference that. I think that does make sense to, but it ends touching a bit more code than I was comfortable doing a PR for without more testing. 