### PR TITLE
Default inverted property to NO

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -153,7 +153,7 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
     [self slk_registerNotifications];
     
     self.bounces = YES;
-    self.inverted = YES;
+    self.inverted = NO;
     self.shakeToClearEnabled = NO;
     self.keyboardPanningEnabled = YES;
     self.shouldClearTextAtRightButtonPress = YES;


### PR DESCRIPTION
Default `inverted` property of `SLKTextViewController` to `NO` as with an out-of-the-box install, everything will be mirrored and flipped unless you set `inverted` to `NO` or add the `cell.transform = self.tableView.transform` line to your `tableView:cellForRowAtIndexPath:` method.

Attached an image of what I was seeing. All I'd done was subclass `SLKTextViewController` and add the `[super initWithTableViewStyle:UITableViewStylePlain]` method. Thought something was severely messed up (was why I thought my typo pull request was wrong https://github.com/slackhq/SlackTextViewController/pull/125#issuecomment-75695055).

@dapenggao's comment in #114 also helped me fix the dark shadow by setting ` self.window.backgroundColor = [UIColor whiteColor]` in AppDelegate.