### PR TITLE
Extra customization hooks

### DIFF
--- a/Source/Classes/SLKTextInputbar.h
+++ b/Source/Classes/SLKTextInputbar.h
@@ -22,7 +22,8 @@
 typedef NS_ENUM(NSUInteger, SLKCounterStyle) {
     SLKCounterStyleNone,
     SLKCounterStyleSplit,
-    SLKCounterStyleCountdown
+    SLKCounterStyleCountdown,
+    SLKCounterStyleCountdownReversed
 };
 
 /** @name A custom tool bar encapsulating messaging controls. */
@@ -113,6 +114,9 @@ typedef NS_ENUM(NSUInteger, SLKCounterStyle) {
 /// @name Text Counting
 ///------------------------------------------------
 
+/** The label used to display the char count. */
+@property (nonatomic, readonly) UILabel *charCountLabel;
+
 /** The maximum character count allowed. If larger than 0, a character count label will be displayed on top of the right button. Default is 0, which means limitless.*/
 @property (nonatomic, readwrite) NSUInteger maxCharCount;
 
@@ -121,5 +125,11 @@ typedef NS_ENUM(NSUInteger, SLKCounterStyle) {
 
 /** YES if the maxmimum character count has been exceeded. */
 @property (nonatomic, readonly) BOOL limitExceeded;
+
+/** Color used for char count label. Default is [UIColor lightGrayColor] */
+@property (nonatomic, strong, readwrite) UIColor *charCountLabelDefaultColor;
+
+/** Color used for char count label when it has exceeded the limit. Default is [UIColor redColor] */
+@property (nonatomic, strong, readwrite) UIColor *charCountLabelLimitExceededColor;
 
 @end

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -68,6 +68,9 @@
 
 - (void)slk_commonInit
 {
+    self.charCountLabelDefaultColor = [UIColor lightGrayColor];
+    self.charCountLabelLimitExceededColor = [UIColor redColor];
+    
     self.autoHideRightButton = YES;
     self.editorContentViewHeight = 38.0;
     self.contentInset = UIEdgeInsetsMake(5.0, 8.0, 5.0, 8.0);
@@ -248,7 +251,7 @@
     }
 }
 
-- (BOOL)slk_limitExceeded
+- (BOOL)limitExceeded
 {
     NSString *text = [self.textView.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     
@@ -406,9 +409,13 @@
     if (self.counterStyle == SLKCounterStyleCountdown) {
         counter = [NSString stringWithFormat:@"%ld", (long)(text.length - self.maxCharCount)];
     }
+    if (self.counterStyle == SLKCounterStyleCountdownReversed)
+    {
+        counter = [NSString stringWithFormat:@"%ld", (long)(self.maxCharCount - text.length)];
+    }
     
     self.charCountLabel.text = counter;
-    self.charCountLabel.textColor = [self slk_limitExceeded] ?  [UIColor redColor] : [UIColor lightGrayColor];
+    self.charCountLabel.textColor = [self limitExceeded] ? self.charCountLabelLimitExceededColor : self.charCountLabelDefaultColor;
 }
 
 
@@ -511,15 +518,8 @@
                               @"rightVerMargin" : @(rightVerMargin),
                               @"minTextViewHeight" : @(self.textView.intrinsicContentSize.height),
                               };
-
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton(0)]-(<=left)-[textView]-(right)-[rightButton(0)]-(right)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton(0)]-(0@750)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=rightVerMargin)-[rightButton]-(<=rightVerMargin)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(<=top)-[charCountLabel]-(>=0)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left@250)-[charCountLabel(<=50@1000)]-(right@750)-|" options:0 metrics:metrics views:views]];
-
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[contentView(0)]-(<=top)-[textView(minTextViewHeight@250)]-(bottom)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:metrics views:views]];
+    
+    [self slk_setupViewContraintsUsingMetrics:metrics views:views];
     
     self.editorContentViewHC = [self slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.editorContentView secondItem:nil];
     
@@ -531,6 +531,18 @@
 
     self.rightButtonWC = [self slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.rightButton secondItem:nil];
     self.rightMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeTrailing][0];
+}
+
+- (void)slk_setupViewContraintsUsingMetrics:(NSDictionary *)metrics views:(NSDictionary *)views
+{
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton(0)]-(<=left)-[textView]-(right)-[rightButton(0)]-(right)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton(0)]-(0@750)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=rightVerMargin)-[rightButton]-(<=rightVerMargin)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(<=top)-[charCountLabel]-(>=0)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left@250)-[charCountLabel(<=50@1000)]-(right@750)-|" options:0 metrics:metrics views:views]];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[contentView(0)]-(<=top)-[textView(minTextViewHeight@250)]-(bottom)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:metrics views:views]];
 }
 
 - (void)slk_updateConstraintConstants

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -416,6 +416,15 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 ///------------------------------------------------
 /// @name Customization
 ///------------------------------------------------
+
+/**
+ Registers a class for customizing the behavior and appearance of the text input bar.
+ You need to call this method inside of any initialization method.
+ 
+ @param textViewClass A SLKTextInputbar subclass.
+ */
+- (void)registerClassForTextInputbar:(Class)textInputBarClass;
+
 /**
  Registers a class for customizing the behavior and appearance of the text view.
  You need to call this method inside of any initialization method.

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -60,6 +60,9 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
 // The setter of isExternalKeyboardDetected, for private use.
 @property (nonatomic, getter = isRotating) BOOL rotating;
 
+// The subclass of SLKTextInputbar class to use
+@property (nonatomic, strong) Class textInputbarClass;
+
 // The subclass of SLKTextView class to use
 @property (nonatomic, strong) Class textViewClass;
 
@@ -291,8 +294,9 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
 - (SLKTextInputbar *)textInputbar
 {
     if (!_textInputbar)
-    {        
-        _textInputbar = [[SLKTextInputbar alloc] initWithTextViewClass:self.textViewClass];
+    {
+        Class class = self.textInputbarClass ? : [SLKTextInputbar class];
+        _textInputbar = [[class alloc] initWithTextViewClass:self.textViewClass];
         _textInputbar.translatesAutoresizingMaskIntoConstraints = NO;
         _textInputbar.controller = self;
         
@@ -1647,6 +1651,16 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
 
 
 #pragma mark - Customization
+
+- (void)registerClassForTextInputbar:(Class)textInputbarClass
+{
+    if (textInputbarClass == nil) {
+        return;
+    }
+    
+    NSAssert([textInputbarClass isSubclassOfClass:[SLKTextInputbar class]], @"The registered class is invalid, it must be a subclass of SLKTextInputbar.");
+    self.textInputbarClass = textInputbarClass;
+}
 
 - (void)registerClassForTextView:(Class)textViewClass
 {


### PR DESCRIPTION
The pull requests implements additional customization hooks:
+ Possible to swap out the SLKTextInputbar for a custom subclass.
+ Possible to customize the char label colors.
+ Possible to setup a different auto-layout system for SLKTextInputbar by replacing `- (void)slk_setupViewContraintsUsingMetrics:(NSDictionary *)metrics views:(NSDictionary *)views`
+ Implemented a reversed countdown which starts by showing the max characters allowed and then counts down to zero.

I also renamed slk_limitExceeded to limitExceeded as it is part of the public API and adding the slk_ prefix seemed to break the enabled state of the send button if you exceed the character limit.
Hope this is useful! 