### PR TITLE
Char Counter Customization Hooks

### DIFF
--- a/Source/Classes/SLKTextInputbar.h
+++ b/Source/Classes/SLKTextInputbar.h
@@ -22,7 +22,13 @@
 typedef NS_ENUM(NSUInteger, SLKCounterStyle) {
     SLKCounterStyleNone,
     SLKCounterStyleSplit,
-    SLKCounterStyleCountdown
+    SLKCounterStyleCountdown,
+    SLKCounterStyleCountdownReversed
+};
+
+typedef NS_ENUM(NSUInteger, SLKCounterLayoutStyle) {
+    SLKCounterLayoutStylePinnedToTop, // Pins the char counter to the top of the input bar.
+    SLKCounterLayoutStylePinnedToRightButton // Pins the char counter to the top of the right button.
 };
 
 /** @name A custom tool bar encapsulating messaging controls. */
@@ -113,13 +119,25 @@ typedef NS_ENUM(NSUInteger, SLKCounterStyle) {
 /// @name Text Counting
 ///------------------------------------------------
 
+/** The label used to display the char count. */
+@property (nonatomic, readonly) UILabel *charCountLabel;
+
 /** The maximum character count allowed. If larger than 0, a character count label will be displayed on top of the right button. Default is 0, which means limitless.*/
 @property (nonatomic, readwrite) NSUInteger maxCharCount;
 
 /** The character counter formatting. Ignored if maxCharCount is 0. Default is None. */
 @property (nonatomic, assign) SLKCounterStyle counterStyle;
 
+/** The character counter layout style. Ignored if maxCharCount is 0. Default is SLKCounterLayoutStylePinnedToTop. */
+@property (nonatomic, assign) SLKCounterLayoutStyle counterLayoutStyle;
+
 /** YES if the maxmimum character count has been exceeded. */
 @property (nonatomic, readonly) BOOL limitExceeded;
+
+/** Color used for char count label. Default is [UIColor lightGrayColor] */
+@property (nonatomic, strong, readwrite) UIColor *charCountLabelDefaultColor;
+
+/** Color used for char count label when it has exceeded the limit. Default is [UIColor redColor] */
+@property (nonatomic, strong, readwrite) UIColor *charCountLabelLimitExceededColor;
 
 @end

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -416,6 +416,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 ///------------------------------------------------
 /// @name Customization
 ///------------------------------------------------
+
 /**
  Registers a class for customizing the behavior and appearance of the text view.
  You need to call this method inside of any initialization method.

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -291,7 +291,7 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
 - (SLKTextInputbar *)textInputbar
 {
     if (!_textInputbar)
-    {        
+    {
         _textInputbar = [[SLKTextInputbar alloc] initWithTextViewClass:self.textViewClass];
         _textInputbar.translatesAutoresizingMaskIntoConstraints = NO;
         _textInputbar.controller = self;


### PR DESCRIPTION
Made it possible to customize the char counter in more details.

+ Introduced the concept of `SLKCounterLayoutStyle` for customizing the layout of the char counter. Implemented `SLKCounterLayoutStylePinnedToRightButton` which pins the char counter to the top of the right button but made `SLKCounterLayoutStylePinnedToTop` be the default behavior.
+ Made it possible to change the colors used for the normal and limit exceeded state of the char counter.
+ Exposed the charCounterLabel to make it easier to use custom fonts.
+ Implemented a new `SLKCounterStyle`: `SLKCounterStyleCountdownReversed` which starts at the maxChars value and counts down to 0.
