### PR TITLE
Macro definition for iOS versions lower than 8

### DIFF
--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -14,6 +14,14 @@
 //   limitations under the License.
 //
 
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
 #import <UIKit/UIKit.h>
 #import "SLKTextInputbar.h"
 #import "SLKTypingIndicatorView.h"


### PR DESCRIPTION
#### :pushpin: Related issue
https://github.com/slackhq/SlackTextViewController/issues/140

#### :tophat: What? Why?
The project I am working on has 7.0 Base SDK, and there's a macro you added on the last commit that is only available on iOS 8.
How I fixed on my project is by adding the macro if it is not defined by the Base SDK.

![](http://i.giphy.com/iNUq5rs9KSrFm.gif)
(A GIF always improves a PR :grin: )