### PR TITLE
Wrong statusBarHeight in iOS 7

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -519,7 +519,8 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
     CGFloat bottomWindow = CGRectGetMaxY(bounds);
     CGFloat bottomView = CGRectGetMaxY(viewRect);
     
-    CGFloat statusBarHeight = CGRectGetHeight([self.view convertRect:[UIApplication sharedApplication].statusBarFrame fromView:nil]);
+    CGRect statusBarRect = [self.view convertRect:[UIApplication sharedApplication].statusBarFrame fromView:nil];
+    CGFloat statusBarHeight = MIN(statusBarRect.size.height, statusBarRect.size.width);
     
     CGFloat bottomMargin = bottomWindow - bottomView;
     


### PR DESCRIPTION
#### :tophat: What? Why?
Related to yesterday's PR, `[UIApplication sharedApplication].statusBarFrame` is returning switched heigh and width in BaseSDK 7.0. That makes the scroll view to be the device width in points bigger that what it should be. Also makes the scroll indicators to not work properly.

#### :ghost: GIF
![](https://s3.amazonaws.com/giphygifs/media/l1UWxyIhsZi8g/giphy.gif)