### PR TITLE
Center right button and update constraints when its size is changed

### DIFF
--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -29,6 +29,8 @@
 @property (nonatomic, strong) NSLayoutConstraint *bottomMarginWC;
 @property (nonatomic, strong) NSLayoutConstraint *rightButtonWC;
 @property (nonatomic, strong) NSLayoutConstraint *rightMarginWC;
+@property (nonatomic, strong) NSLayoutConstraint *rightButtonTopMarginC;
+@property (nonatomic, strong) NSLayoutConstraint *rightButtonBottomMarginC;
 @property (nonatomic, strong) NSLayoutConstraint *editorContentViewHC;
 @property (nonatomic, strong) NSArray *charCountLabelVCs;
 
@@ -92,6 +94,7 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(slk_didChangeTextViewContentSize:) name:SLKTextViewContentSizeDidChangeNotification object:nil];
     
     [self.leftButton.imageView addObserver:self forKeyPath:NSStringFromSelector(@selector(image)) options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL];
+    [self.rightButton.titleLabel addObserver:self forKeyPath:NSStringFromSelector(@selector(font)) options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL];
 }
 
 
@@ -576,6 +579,9 @@
 
     self.rightButtonWC = [self slk_constraintForAttribute:NSLayoutAttributeWidth firstItem:self.rightButton secondItem:nil];
     self.rightMarginWC = [self slk_constraintsForAttribute:NSLayoutAttributeTrailing][0];
+    
+    self.rightButtonTopMarginC = [self slk_constraintForAttribute:NSLayoutAttributeTop firstItem:self.rightButton secondItem:self];
+    self.rightButtonBottomMarginC = [self slk_constraintForAttribute:NSLayoutAttributeBottom firstItem:self secondItem:self.rightButton];
 }
 
 - (void)slk_updateConstraintConstants
@@ -607,6 +613,13 @@
         
         self.rightButtonWC.constant = [self slk_appropriateRightButtonWidth];
         self.rightMarginWC.constant = [self slk_appropriateRightButtonMargin];
+        
+        [self.rightButton sizeToFit];
+        
+        CGFloat rightVerMargin = (self.intrinsicContentSize.height - CGRectGetHeight(self.rightButton.frame)) / 2.0;
+        
+        self.rightButtonTopMarginC.constant = rightVerMargin;
+        self.rightButtonBottomMarginC.constant = rightVerMargin;
     }
 }
 
@@ -624,6 +637,9 @@
         
         [self slk_updateConstraintConstants];
     }
+    else if ([object isEqual:self.rightButton.titleLabel] && [keyPath isEqualToString:NSStringFromSelector(@selector(font))]) {
+        [self slk_updateConstraintConstants];
+    }
     else {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
@@ -638,6 +654,7 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self name:SLKTextViewContentSizeDidChangeNotification object:nil];
     
     [_leftButton.imageView removeObserver:self forKeyPath:NSStringFromSelector(@selector(image))];
+    [_rightButton.titleLabel removeObserver:self forKeyPath:NSStringFromSelector(@selector(font))];
     
     _leftButton = nil;
     _rightButton = nil;
@@ -656,6 +673,8 @@
     _bottomMarginWC = nil;
     _rightButtonWC = nil;
     _rightMarginWC = nil;
+    _rightButtonTopMarginC = nil;
+    _rightButtonBottomMarginC = nil;
     _editorContentViewHC = nil;
 }
 

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -538,11 +538,8 @@
 
 - (void)slk_setupViewConstraints
 {
-    UIImage *leftButtonImg = [self.leftButton imageForState:UIControlStateNormal];
-    
     [self.rightButton sizeToFit];
     
-    CGFloat leftVerMargin = (self.intrinsicContentSize.height - leftButtonImg.size.height) / 2.0;
     CGFloat rightVerMargin = (self.intrinsicContentSize.height - CGRectGetHeight(self.rightButton.frame)) / 2.0;
 
     NSDictionary *views = @{@"textView": self.textView,
@@ -556,7 +553,6 @@
                               @"bottom" : @(self.contentInset.bottom),
                               @"left" : @(self.contentInset.left),
                               @"right" : @(self.contentInset.right),
-                              @"leftVerMargin" : @(leftVerMargin),
                               @"rightVerMargin" : @(rightVerMargin),
                               @"minTextViewHeight" : @(self.textView.intrinsicContentSize.height),
                               };


### PR DESCRIPTION
We noticed, just like described in #57, that increasing the font size for the right button didn't update the already set constraints. That had the following effect in our case:

![ios 8 3 12f69 2015-05-07 12-01-31](https://cloud.githubusercontent.com/assets/1638459/7512950/d11368c2-f4b0-11e4-835d-b31df6d1bd46.png)

This fix uses KVO as proposed in the closed issue, but please feel free to give feedback.

Thanks a lot for this great library!