### PR TITLE
Fixed autocomplete on Japanese keyboards

### DIFF
--- a/Source/Classes/SLKTextView.m
+++ b/Source/Classes/SLKTextView.m
@@ -362,6 +362,15 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
         return;
     }
     
+    // Toggling autocorrect on Japanese keyboards breaks autocompletion.
+    // If you try typing "@" on a Japanese keyboard toggling the autocomplete causes iOS
+    // to set the textView's text to an empty string.
+    // My thought is that this is caused by the same mechanism that forces autocorrection
+    // to be committed when refreshing the first responder.
+    if ([self.textInputMode.primaryLanguage isEqualToString:@"ja-JP"]) {
+        return;
+    }
+    
     self.autocorrectionType = enabled ? UITextAutocorrectionTypeDefault : UITextAutocorrectionTypeNo;
     self.spellCheckingType = enabled ? UITextSpellCheckingTypeDefault : UITextSpellCheckingTypeNo;
     


### PR DESCRIPTION
Toggling autocorrect on Japanese keyboards breaks autocompletion.

If you try typing "@" on a Japanese keyboard toggling the autocomplete causes iOS to set the textView's text to an empty string.

My thought is that this is caused by the same mechanism that forces autocorrection to be committed when refreshing the first responder.

This fixes the issue. Tested on a bunch of other international keyboards and others were fine. Only `ja-JP` was affected.