### PR TITLE
If right button title is not present, use image size to determine the width

### DIFF
--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -316,15 +316,22 @@
 
 - (CGFloat)slk_appropriateRightButtonWidth
 {
-    NSString *title = [self.rightButton titleForState:UIControlStateNormal];
-    CGSize rigthButtonSize = [title sizeWithAttributes:@{NSFontAttributeName: self.rightButton.titleLabel.font}];
-    
     if (self.autoHideRightButton) {
         if (self.textView.text.length == 0) {
             return 0.0;
         }
     }
-    return rigthButtonSize.width+self.contentInset.right;
+
+    NSString *title = [self.rightButton titleForState:UIControlStateNormal];
+
+    CGSize rightButtonSize;
+    if ([title length] == 0 && self.rightButton.imageView.image) {
+        rightButtonSize = self.rightButton.imageView.image.size;
+    } else {
+        rightButtonSize = [title sizeWithAttributes:@{NSFontAttributeName: self.rightButton.titleLabel.font}];
+    }
+
+    return rightButtonSize.width+self.contentInset.right;
 }
 
 - (CGFloat)slk_appropriateRightButtonMargin


### PR DESCRIPTION
I wanted to use an image without text for the right button, but needed to update the `slk_appropriateRightButtonWidth` function to support this.

