### PR TITLE
Adds custom typing indicator support

### DIFF
--- a/Examples/Messenger-Shared/MessageTableViewCell.h
+++ b/Examples/Messenger-Shared/MessageTableViewCell.h
@@ -8,8 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-#define kAvatarSize 30.0
-#define kMinimumHeight 50.0
+static CGFloat kMessageTableViewCellMinimumHeight = 50.0;
+static CGFloat kMessageTableViewCellAvatarHeight = 30.0;
 
 @interface MessageTableViewCell : UITableViewCell
 

--- a/Examples/Messenger-Shared/MessageTableViewCell.m
+++ b/Examples/Messenger-Shared/MessageTableViewCell.m
@@ -35,18 +35,19 @@
                             @"attachmentView": self.attachmentView,
                             };
     
-    NSDictionary *metrics = @{@"tumbSize": @(kAvatarSize),
-                              @"trailing": @10,
-                              @"leading": @5,
+    NSDictionary *metrics = @{@"tumbSize": @(kMessageTableViewCellAvatarHeight),
+                              @"padding": @15,
+                              @"right": @10,
+                              @"left": @5,
                               @"attchSize": @80,
                               };
     
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-leading-[thumbnailView(tumbSize)]-trailing-[titleLabel(>=0)]-trailing-|" options:0 metrics:metrics views:views]];
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-leading-[thumbnailView(tumbSize)]-trailing-[bodyLabel(>=0)]-trailing-|" options:0 metrics:metrics views:views]];
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-leading-[thumbnailView(tumbSize)]-trailing-[attachmentView]-trailing-|" options:0 metrics:metrics views:views]];
+    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-left-[thumbnailView(tumbSize)]-right-[titleLabel(>=0)]-right-|" options:0 metrics:metrics views:views]];
+    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-left-[thumbnailView(tumbSize)]-right-[bodyLabel(>=0)]-right-|" options:0 metrics:metrics views:views]];
+    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-left-[thumbnailView(tumbSize)]-right-[attachmentView]-right-|" options:0 metrics:metrics views:views]];
 
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-trailing-[thumbnailView(tumbSize)]-(>=0)-|" options:0 metrics:metrics views:views]];
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-15-[titleLabel]-leading-[bodyLabel(>=0)]-leading-[attachmentView(>=0,<=attchSize)]-trailing-|" options:0 metrics:metrics views:views]];
+    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-right-[thumbnailView(tumbSize)]-(>=0)-|" options:0 metrics:metrics views:views]];
+    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-padding-[titleLabel]-left-[bodyLabel(>=0)]-left-[attachmentView(>=0,<=attchSize)]-right-|" options:0 metrics:metrics views:views]];
 }
 
 - (void)prepareForReuse
@@ -100,7 +101,7 @@
         _thumbnailView.userInteractionEnabled = NO;
         _thumbnailView.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1.0];
         
-        _thumbnailView.layer.cornerRadius = kAvatarSize/2.0;
+        _thumbnailView.layer.cornerRadius = kMessageTableViewCellAvatarHeight/2.0;
         _thumbnailView.layer.masksToBounds = YES;
     }
     return _thumbnailView;
@@ -115,7 +116,7 @@
         _attachmentView.backgroundColor = [UIColor clearColor];
         _attachmentView.contentMode = UIViewContentModeCenter;
         
-        _attachmentView.layer.cornerRadius = kAvatarSize/4.0;
+        _attachmentView.layer.cornerRadius = kMessageTableViewCellAvatarHeight/4.0;
         _attachmentView.layer.masksToBounds = YES;
     }
     return _attachmentView;

--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -162,7 +162,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     if ([self canShowTypingIndicator]) {
         
 #if DEBUG_CUSTOM_TYPING_INDICATOR
-        __block TypingIndicatorView *view = (TypingIndicatorView *)self.typingIndicatorCustomView;
+        __block TypingIndicatorView *view = (TypingIndicatorView *)self.typingIndicatorProxyView;
         
         CGFloat scale = [UIScreen mainScreen].scale;
         CGSize imgSize = CGSizeMake(kTypingIndicatorViewAvatarHeight*scale, kTypingIndicatorViewAvatarHeight*scale);

--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -9,9 +9,12 @@
 #import "MessageViewController.h"
 #import "MessageTableViewCell.h"
 #import "MessageTextView.h"
+#import "TypingIndicatorView.h"
 #import "Message.h"
 
 #import <LoremIpsum/LoremIpsum.h>
+
+#define DEBUG_CUSTOM_TYPING_INDICATOR 0
 
 static NSString *MessengerCellIdentifier = @"MessengerCell";
 static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
@@ -34,8 +37,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 {
     self = [super initWithTableViewStyle:UITableViewStylePlain];
     if (self) {
-        // Register a subclass of SLKTextView, if you need any special appearance and/or behavior customisation.
-        [self registerClassForTextView:[MessageTextView class]];
+        [self commonInit];
     }
     return self;
 }
@@ -44,8 +46,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        // Register a subclass of SLKTextView, if you need any special appearance and/or behavior customisation.
-        [self registerClassForTextView:[MessageTextView class]];
+        [self commonInit];
     }
     return self;
 }
@@ -53,6 +54,17 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 + (UITableViewStyle)tableViewStyleForCoder:(NSCoder *)decoder
 {
     return UITableViewStylePlain;
+}
+
+- (void)commonInit
+{
+    // Register a SLKTextView subclass, if you need any special appearance and/or behavior customisation.
+    [self registerClassForTextView:[MessageTextView class]];
+    
+#if DEBUG_CUSTOM_TYPING_INDICATOR
+    // Register a UIView subclass, conforming to SLKTypingIndicatorProtocol, to use a custom typing indicator view.
+    [self registerClassForTypingIndicatorView:[TypingIndicatorView class]];
+#endif
 }
 
 
@@ -111,7 +123,9 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     self.textInputbar.counterStyle = SLKCounterStyleSplit;
     self.textInputbar.counterPosition = SLKCounterPositionTop;
 
+#if !DEBUG_CUSTOM_TYPING_INDICATOR
     self.typingIndicatorView.canResignByTouch = YES;
+#endif
     
     [self.autoCompletionView registerClass:[MessageTableViewCell class] forCellReuseIdentifier:AutoCompletionCellIdentifier];
     [self registerPrefixesForAutoCompletion:@[@"@", @"#", @":"]];
@@ -145,8 +159,23 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 
 - (void)simulateUserTyping:(id)sender
 {
-    if (!self.isEditing && !self.isAutoCompleting) {
+    if ([self canShowTypingIndicator]) {
+        
+#if DEBUG_CUSTOM_TYPING_INDICATOR
+        __block TypingIndicatorView *view = (TypingIndicatorView *)self.typingIndicatorCustomView;
+        
+        CGFloat scale = [UIScreen mainScreen].scale;
+        CGSize imgSize = CGSizeMake(kTypingIndicatorViewAvatarHeight*scale, kTypingIndicatorViewAvatarHeight*scale);
+        
+        // This will cause the typing indicator to show after a delay ¯\_(ツ)_/¯
+        [LoremIpsum asyncPlaceholderImageWithSize:imgSize
+                                       completion:^(UIImage *image) {
+                                           UIImage *thumbnail = [UIImage imageWithCGImage:image.CGImage scale:scale orientation:UIImageOrientationUp];
+                                           [view presentIndicatorWithName:[LoremIpsum name] image:thumbnail];
+                                       }];
+#else
         [self.typingIndicatorView insertUsername:[LoremIpsum name]];
+#endif
     }
 }
 
@@ -322,6 +351,15 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     return [super canPressRightButton];
 }
 
+- (BOOL)canShowTypingIndicator
+{
+#if DEBUG_CUSTOM_TYPING_INDICATOR
+    return YES;
+#else
+    return [super canShowTypingIndicator];
+#endif
+}
+
 - (BOOL)canShowAutoCompletion
 {
     NSArray *array = nil;
@@ -414,12 +452,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     if (cell.needsPlaceholder)
     {
         CGFloat scale = [UIScreen mainScreen].scale;
-        
-        if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]) {
-            scale = [UIScreen mainScreen].nativeScale;
-        }
-        
-        CGSize imgSize = CGSizeMake(kAvatarSize*scale, kAvatarSize*scale);
+        CGSize imgSize = CGSizeMake(kMessageTableViewCellAvatarHeight*scale, kMessageTableViewCellAvatarHeight*scale);
         
         [LoremIpsum asyncPlaceholderImageWithSize:imgSize
                                        completion:^(UIImage *image) {
@@ -470,7 +503,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
         NSDictionary *attributes = @{NSFontAttributeName: [UIFont systemFontOfSize:16.0],
                                      NSParagraphStyleAttributeName: paragraphStyle};
         
-        CGFloat width = CGRectGetWidth(tableView.frame)-kAvatarSize;
+        CGFloat width = CGRectGetWidth(tableView.frame)-kMessageTableViewCellAvatarHeight;
         width -= 25.0;
         
         CGRect titleBounds = [message.username boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin attributes:attributes context:NULL];
@@ -487,14 +520,14 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
             height += 80.0 + 10.0;
         }
         
-        if (height < kMinimumHeight) {
-            height = kMinimumHeight;
+        if (height < kMessageTableViewCellMinimumHeight) {
+            height = kMessageTableViewCellMinimumHeight;
         }
         
         return height;
     }
     else {
-        return kMinimumHeight;
+        return kMessageTableViewCellMinimumHeight;
     }
 }
 

--- a/Examples/Messenger-Shared/TypingIndicatorView.h
+++ b/Examples/Messenger-Shared/TypingIndicatorView.h
@@ -1,0 +1,20 @@
+//
+//  TypingIndicatorView.h
+//  Messenger
+//
+//  Created by Ignacio Romero Z. on 6/27/15.
+//  Copyright (c) 2015 Slack Technologies, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "SLKTypingIndicatorProtocol.h"
+
+static CGFloat kTypingIndicatorViewMinimumHeight = 80.0;
+static CGFloat kTypingIndicatorViewAvatarHeight = 30.0;
+
+@interface TypingIndicatorView : UIView <SLKTypingIndicatorProtocol>
+
+- (void)presentIndicatorWithName:(NSString *)name image:(UIImage *)image;
+- (void)dismissIndicator;
+
+@end

--- a/Examples/Messenger-Shared/TypingIndicatorView.m
+++ b/Examples/Messenger-Shared/TypingIndicatorView.m
@@ -36,31 +36,22 @@
                             @"titleLabel": self.titleLabel
                             };
     
-    NSDictionary *metrics = @{@"tumbSize": @(kTypingIndicatorViewAvatarHeight),
-                              @"tumbSizeHalf": @(-kTypingIndicatorViewAvatarHeight/2.0),
+    NSDictionary *metrics = @{@"invertedThumbSize": @(-kTypingIndicatorViewAvatarHeight/2.0),
                               };
     
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-5-[thumbnailView]-10-[titleLabel]-(>=0)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[thumbnailView]-(tumbSizeHalf)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[thumbnailView]-(invertedThumbSize)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[titleLabel]-(3@750)-|" options:0 metrics:metrics views:views]];
 }
 
 
 #pragma mark - SLKTypingIndicatorProtocol
 
-- (void)setVisible:(BOOL)visible
+- (void)dismissIndicator
 {
-    if (visible == self.isVisible) {
-        return;
+    if (self.isVisible) {
+        self.visible = NO;
     }
-    
-    // Required implementation for key-value observer compliance
-    [self willChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
-    
-    _visible = visible;
-    
-    // Required implementation for key-value observer compliance
-    [self didChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
 }
 
 
@@ -154,13 +145,6 @@
     self.thumbnailView.image = image;
 
     self.visible = YES;
-}
-
-- (void)dismissIndicator
-{
-    if (self.isVisible) {
-        self.visible = NO;
-    }
 }
 
 

--- a/Examples/Messenger-Shared/TypingIndicatorView.m
+++ b/Examples/Messenger-Shared/TypingIndicatorView.m
@@ -1,0 +1,191 @@
+//
+//  TypingIndicatorView.m
+//  Messenger
+//
+//  Created by Ignacio Romero Z. on 6/27/15.
+//  Copyright (c) 2015 Slack Technologies, Inc. All rights reserved.
+//
+
+#import "TypingIndicatorView.h"
+
+@interface TypingIndicatorView ()
+@property (nonatomic, strong) UIImageView *thumbnailView;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) CAGradientLayer *backgroundGradient;
+@end
+
+@implementation TypingIndicatorView
+@synthesize visible = _visible;
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        [self configureSubviews];
+    }
+    return self;
+}
+
+- (void)configureSubviews
+{
+    [self addSubview:self.thumbnailView];
+    [self addSubview:self.titleLabel];
+    [self.layer insertSublayer:self.backgroundGradient atIndex:0];
+
+    NSDictionary *views = @{@"thumbnailView": self.thumbnailView,
+                            @"titleLabel": self.titleLabel
+                            };
+    
+    NSDictionary *metrics = @{@"tumbSize": @(kTypingIndicatorViewAvatarHeight),
+                              @"tumbSizeHalf": @(-kTypingIndicatorViewAvatarHeight/2.0),
+                              };
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-5-[thumbnailView]-10-[titleLabel]-(>=0)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[thumbnailView]-(tumbSizeHalf)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[titleLabel]-(3@750)-|" options:0 metrics:metrics views:views]];
+}
+
+
+#pragma mark - SLKTypingIndicatorProtocol
+
+- (void)setVisible:(BOOL)visible
+{
+    if (visible == self.isVisible) {
+        return;
+    }
+    
+    // Required implementation for key-value observer compliance
+    [self willChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
+    
+    _visible = visible;
+    
+    // Required implementation for key-value observer compliance
+    [self didChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
+}
+
+
+#pragma mark - UIView
+
+- (CGSize)intrinsicContentSize
+{
+    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.backgroundGradient.frame = self.bounds;
+}
+
+
+#pragma mark - Getters
+
+- (UIImageView *)thumbnailView
+{
+    if (!_thumbnailView) {
+        _thumbnailView = [UIImageView new];
+        _thumbnailView.translatesAutoresizingMaskIntoConstraints = NO;
+        _thumbnailView.userInteractionEnabled = NO;
+        _thumbnailView.backgroundColor = [UIColor grayColor];
+        _thumbnailView.contentMode = UIViewContentModeTopLeft;
+
+        _thumbnailView.layer.cornerRadius = kTypingIndicatorViewAvatarHeight/2.0;
+        _thumbnailView.layer.masksToBounds = YES;
+    }
+    return _thumbnailView;
+}
+
+- (UILabel *)titleLabel
+{
+    if (!_titleLabel) {
+        _titleLabel = [UILabel new];
+        _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        _titleLabel.backgroundColor = [UIColor clearColor];
+        _titleLabel.userInteractionEnabled = NO;
+        _titleLabel.numberOfLines = 1;
+        _titleLabel.contentMode = UIViewContentModeTopLeft;
+        
+        _titleLabel.font = [UIFont systemFontOfSize:12.0];
+        _titleLabel.textColor = [UIColor lightGrayColor];
+    }
+    return _titleLabel;
+}
+
+- (CAGradientLayer *)backgroundGradient
+{
+    if (!_backgroundGradient) {
+        _backgroundGradient = [CAGradientLayer layer];
+        _backgroundGradient.frame = CGRectMake(0.0, 0.0, [UIScreen mainScreen].bounds.size.width, [self height]);
+        
+        _backgroundGradient.colors = @[(id)[UIColor colorWithWhite:1.0 alpha:0].CGColor,
+                                       (id)[UIColor colorWithWhite:1.0 alpha:0.9].CGColor,
+                                       (id)[UIColor colorWithWhite:1.0 alpha:1.0].CGColor];
+        
+        _backgroundGradient.locations = @[@0, @0.5, @1];
+        _backgroundGradient.rasterizationScale = [UIScreen mainScreen].scale;
+        _backgroundGradient.shouldRasterize = YES;
+    }
+    return _backgroundGradient;
+}
+
+- (CGFloat)height
+{
+    CGFloat height = 13.0;
+    height += self.titleLabel.font.lineHeight;
+    return height;
+}
+
+
+#pragma mark - TypingIndicatorView
+
+- (void)presentIndicatorWithName:(NSString *)name image:(UIImage *)image
+{
+    if (self.isVisible || name.length == 0 || !image) {
+        return;
+    }
+    
+    NSString *text = [NSString stringWithFormat:@"%@ is typing...", name];
+    
+    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:text];
+    [attributedString addAttributes:@{NSFontAttributeName: [UIFont boldSystemFontOfSize:12.0]} range:[text rangeOfString:name]];
+    
+    self.titleLabel.attributedText = attributedString;
+    self.thumbnailView.image = image;
+
+    self.visible = YES;
+}
+
+- (void)dismissIndicator
+{
+    if (self.isVisible) {
+        self.visible = NO;
+    }
+}
+
+
+#pragma mark - Hit Testing
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
+    
+    [self dismissIndicator];
+}
+
+
+#pragma mark - Lifeterm
+
+- (void)dealloc
+{
+    _titleLabel = nil;
+    _thumbnailView = nil;
+    _backgroundGradient = nil;
+}
+
+@end

--- a/Examples/Messenger-Shared/TypingIndicatorView.m
+++ b/Examples/Messenger-Shared/TypingIndicatorView.m
@@ -47,6 +47,11 @@
 
 #pragma mark - SLKTypingIndicatorProtocol
 
+- (CGSize)intrinsicContentSize
+{
+    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
+}
+
 - (void)dismissIndicator
 {
     if (self.isVisible) {
@@ -56,11 +61,6 @@
 
 
 #pragma mark - UIView
-
-- (CGSize)intrinsicContentSize
-{
-    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
-}
 
 - (void)layoutSubviews
 {

--- a/Examples/Messenger-Shared/TypingIndicatorView.m
+++ b/Examples/Messenger-Shared/TypingIndicatorView.m
@@ -47,11 +47,6 @@
 
 #pragma mark - SLKTypingIndicatorProtocol
 
-- (CGSize)intrinsicContentSize
-{
-    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
-}
-
 - (void)dismissIndicator
 {
     if (self.isVisible) {
@@ -118,6 +113,11 @@
         _backgroundGradient.shouldRasterize = YES;
     }
     return _backgroundGradient;
+}
+
+- (CGSize)intrinsicContentSize
+{
+    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
 }
 
 - (CGFloat)height

--- a/Examples/Messenger.xcodeproj/project.pbxproj
+++ b/Examples/Messenger.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4F8ADA781A68C37400023752 /* Message.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8ADA761A68C37400023752 /* Message.m */; };
 		4F8ADA791A68C37400023752 /* Message.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8ADA761A68C37400023752 /* Message.m */; };
 		4F9DFA7F1AD4EDB900841D98 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9DFA7D1AD4EDB100841D98 /* ViewController.m */; };
+		4FF04E591B3F7A04004C3BED /* TypingIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF04E581B3F7A04004C3BED /* TypingIndicatorView.m */; };
 		71BE10281A72F3E50083EE32 /* MessageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F86BF9219F01234007A3D4A /* MessageViewController.m */; };
 		71BE10291A72F3E50083EE32 /* MessageTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F86BF9019F01234007A3D4A /* MessageTableViewCell.m */; };
 		71BE102B1A72F3E50083EE32 /* Message.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8ADA761A68C37400023752 /* Message.m */; };
@@ -92,6 +93,8 @@
 		4F8ADA761A68C37400023752 /* Message.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Message.m; sourceTree = "<group>"; };
 		4F9DFA7C1AD4EDB100841D98 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		4F9DFA7D1AD4EDB100841D98 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		4FF04E571B3F7A04004C3BED /* TypingIndicatorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypingIndicatorView.h; sourceTree = "<group>"; };
+		4FF04E581B3F7A04004C3BED /* TypingIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TypingIndicatorView.m; sourceTree = "<group>"; };
 		622BF1F6C9CF013275EF6275 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		6CA1AF2A9EFDCB40E89F297F /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		71BE10021A72F3130083EE32 /* Messenger-iPad-Sheet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Messenger-iPad-Sheet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -284,6 +287,8 @@
 				4F86BF9019F01234007A3D4A /* MessageTableViewCell.m */,
 				4F7C6BA31A6E208E006E3FAB /* MessageTextView.h */,
 				4F7C6BA41A6E208E006E3FAB /* MessageTextView.m */,
+				4FF04E571B3F7A04004C3BED /* TypingIndicatorView.h */,
+				4FF04E581B3F7A04004C3BED /* TypingIndicatorView.m */,
 				4F8ADA751A68C37400023752 /* Message.h */,
 				4F8ADA761A68C37400023752 /* Message.m */,
 				4F86BF8E19F01234007A3D4A /* Images.xcassets */,
@@ -616,6 +621,7 @@
 				4F3EDB5D199ED00F004C15D6 /* AppDelegate.m in Sources */,
 				4F8ADA771A68C37400023752 /* Message.m in Sources */,
 				4F86BF9519F01234007A3D4A /* MessageTableViewCell.m in Sources */,
+				4FF04E591B3F7A04004C3BED /* TypingIndicatorView.m in Sources */,
 				4F3EDB59199ED00F004C15D6 /* main.m in Sources */,
 				4F32561E1AA77431008C1DD9 /* MessageTextView.m in Sources */,
 			);

--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - LoremIpsum (1.0.0)
-  - SlackTextViewController (1.5)
+  - SlackTextViewController (1.5.2)
 
 DEPENDENCIES:
   - LoremIpsum (~> 1.0)
@@ -12,6 +12,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   LoremIpsum: 9029c55d36501b2ee0b05cc9ecda11d3a0479160
-  SlackTextViewController: 753fa65529f3bb63a4b3568e305dee62e4c4251a
+  SlackTextViewController: 2a3f79c474e41f50b22a8498c510a4da05e207de
 
 COCOAPODS: 0.35.0

--- a/Examples/Pods/Headers/Build/SlackTextViewController/Classes/SLKTypingIndicatorProtocol.h
+++ b/Examples/Pods/Headers/Build/SlackTextViewController/Classes/SLKTypingIndicatorProtocol.h
@@ -1,0 +1,1 @@
+../../../../../../Source/Classes/SLKTypingIndicatorProtocol.h

--- a/Examples/Pods/Headers/Public/SlackTextViewController/Classes/SLKTypingIndicatorProtocol.h
+++ b/Examples/Pods/Headers/Public/SlackTextViewController/Classes/SLKTypingIndicatorProtocol.h
@@ -1,0 +1,1 @@
+../../../../../../Source/Classes/SLKTypingIndicatorProtocol.h

--- a/Examples/Pods/Local Podspecs/SlackTextViewController.podspec
+++ b/Examples/Pods/Local Podspecs/SlackTextViewController.podspec
@@ -1,4 +1,4 @@
-@version = "1.5"
+@version = "1.5.2"
 
 Pod::Spec.new do |s|
   s.name         		= "SlackTextViewController"

--- a/Examples/Pods/Manifest.lock
+++ b/Examples/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
   - LoremIpsum (1.0.0)
-  - SlackTextViewController (1.5)
+  - SlackTextViewController (1.5.2)
 
 DEPENDENCIES:
   - LoremIpsum (~> 1.0)
@@ -12,6 +12,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   LoremIpsum: 9029c55d36501b2ee0b05cc9ecda11d3a0479160
-  SlackTextViewController: 753fa65529f3bb63a4b3568e305dee62e4c4251a
+  SlackTextViewController: 2a3f79c474e41f50b22a8498c510a4da05e207de
 
 COCOAPODS: 0.35.0

--- a/Examples/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,1758 +1,709 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>01B1AAAD850C2FE7EBE72A5C</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>68AF99EFDFA0F4D2B8A2D179</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>0D58ED572A1ADF04E67725C8</string>
-			<key>remoteInfo</key>
-			<string>Pods-SlackTextViewController</string>
-		</dict>
-		<key>0221E66B4D6AB224183BB400</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-LoremIpsum-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>026057F812A343B5F5E603A1</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2EF59B311C7619B63ABA6FD7</string>
-			<key>buildPhases</key>
-			<array>
-				<string>19AA7D6825B8C07CA240B04F</string>
-				<string>57CC223D0C3B3805EE837CD9</string>
-				<string>652A6A83844FAB3EA88FCAB4</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-LoremIpsum</string>
-			<key>productName</key>
-			<string>Pods-LoremIpsum</string>
-			<key>productReference</key>
-			<string>4F59C5D29BEFDE91020956A4</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>0B577FC056DE5C5E8943C3E8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CBF0392BCE6BCBE3EEAF94CB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B69D1A854032ABEDDD24621</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-SlackTextViewController.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0D58ED572A1ADF04E67725C8</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>D22151F997D5E629EC2859E5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>7193EEF66D43A33AB53F619D</string>
-				<string>E32A5742B48F2DF95176F608</string>
-				<string>84D30FA4DCBE3035D622F868</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-SlackTextViewController</string>
-			<key>productName</key>
-			<string>Pods-SlackTextViewController</string>
-			<key>productReference</key>
-			<string>E8BF4FDE1B5C188C2DF89776</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>0D746B13F5C4AE9D48AF9DEA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EBF4016A24EB31D4DFD41F25</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>110C248B665E30FB3A6CC0E5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-LoremIpsum</string>
-			<key>target</key>
-			<string>026057F812A343B5F5E603A1</string>
-			<key>targetProxy</key>
-			<string>1622FACAB9041DACC746F47D</string>
-		</dict>
-		<key>14794F6A897FAFA08EADBACD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECAF5199780DD9A7948E7AF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1605EDC59602F5DA5E26D81E</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>1622FACAB9041DACC746F47D</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>68AF99EFDFA0F4D2B8A2D179</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>026057F812A343B5F5E603A1</string>
-			<key>remoteInfo</key>
-			<string>Pods-LoremIpsum</string>
-		</dict>
-		<key>174ECC3F2A7DB04D0B12A0BA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-SlackTextViewController</string>
-			<key>target</key>
-			<string>0D58ED572A1ADF04E67725C8</string>
-			<key>targetProxy</key>
-			<string>01B1AAAD850C2FE7EBE72A5C</string>
-		</dict>
-		<key>185479967F501F27CCB77F6A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F10BBC109012E9D86E3FE50B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>19AA7D6825B8C07CA240B04F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2E1E10EC0A1EA55CE0644849</string>
-				<string>8B9B5AEF0435BA61A36D8C1E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1DEFBA6408892FCDF9CD0CBE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E1BCD678DFF385194502B3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1EACB7F5CD175594A6A8F3C8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2483AD5B0E7A58A4213726FE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AF1156D3A6D77F7FC1146427</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252C732A988DD78D0A3F4968</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>789E488758B8458061450832</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>26796A46D7611A091085716B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKTextViewController.h</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTextViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2E1E10EC0A1EA55CE0644849</key>
-		<dict>
-			<key>fileRef</key>
-			<string>52D9CD26E3174AEE197B6D13</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-DOS_OBJECT_USE_OBJC=0</string>
-			</dict>
-		</dict>
-		<key>2ED36F5D523634A20C27685B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>75C781511AFB806BFE7E3B84</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2EF59B311C7619B63ABA6FD7</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>80632934078B19B08DDB5E5E</string>
-				<string>D0355FADDEB8E3F97DA68E56</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>3056646B71C947E10280766F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C5F59E253F8FE07410EB6634</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>36C9A6EB45792118AF223C70</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6B97421C692BA2A16148F1A7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>37402AC9C43922969CBB3D66</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>73A7964DDB28B1010D2BBADD</string>
-				<string>4F59C5D29BEFDE91020956A4</string>
-				<string>E8BF4FDE1B5C188C2DF89776</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>40404A89F573301F72B104E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>45A8D243F4C1E3EA2D8DAD0F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>414B1D4986542762EBE5724D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>414BAEC47215A0DE3C3AEA52</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>920BD825DD40FBFB3194C5D2</string>
-				<string>52D9CD26E3174AEE197B6D13</string>
-				<string>FA790F678829AF1B76A86E3F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>LoremIpsum</string>
-			<key>path</key>
-			<string>LoremIpsum</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>43024C52D057BF27FDB6B12E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>UIScrollView+SLKAdditions.m</string>
-			<key>path</key>
-			<string>Source/Additions/UIScrollView+SLKAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>43B48171EE8F1ADC81693F05</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACC21FCA3CB9BE2674C87FE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>43C73CFF53FC3A2EB5078DF9</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>70FE88017383F295009FC372</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>43E948FF24C4D5A3C14D7B0B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>UIResponder+SLKAdditions.m</string>
-			<key>path</key>
-			<string>Source/Additions/UIResponder+SLKAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>45A8D243F4C1E3EA2D8DAD0F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>SLKTextView.m</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4F59C5D29BEFDE91020956A4</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-LoremIpsum.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>509B079B088E5C32FE3627C3</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>414BAEC47215A0DE3C3AEA52</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>52D9CD26E3174AEE197B6D13</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>LoremIpsum.m</string>
-			<key>path</key>
-			<string>LoremIpsum/LoremIpsum.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5409018A02A1ECBC678D233E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>SLKTypingIndicatorView.m</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTypingIndicatorView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>57163ED5AF931BCDEA2F7EA2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>57CC223D0C3B3805EE837CD9</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>8986B7DEAD88EB7796BEE683</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>580CDF3D2ADC59D7876C55DB</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E5482AB14027B22416E5573E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>5AB0B3E647E47454DFA5B5D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>43E948FF24C4D5A3C14D7B0B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5CA11889F1446E3FD13358C9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>SLKInputAccessoryView.m</string>
-			<key>path</key>
-			<string>Source/Classes/SLKInputAccessoryView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5E1BCD678DFF385194502B3A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>SLKTextInputbar.m</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTextInputbar.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5EC201BF62456DD04F2EDA3C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E41E2B16AD747D73700C2DA1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>5FD7DAF58C678CF08753C2CF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5CA11889F1446E3FD13358C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>652A6A83844FAB3EA88FCAB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>DCABAA9C1503D7BFA0FC46D4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>68AF99EFDFA0F4D2B8A2D179</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>DA87404005118305B5D9AA7F</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>9C6779A4699AC850D8441CF1</string>
-			<key>productRefGroup</key>
-			<string>37402AC9C43922969CBB3D66</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>9978AE8EEA74043E81ECAFB2</string>
-				<string>026057F812A343B5F5E603A1</string>
-				<string>0D58ED572A1ADF04E67725C8</string>
-			</array>
-		</dict>
-		<key>6AB23B650927DAFEB1E0911C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6B97421C692BA2A16148F1A7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKTextView.h</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>70FE88017383F295009FC372</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7193EEF66D43A33AB53F619D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>98FA7FBCBE6BE9D681418C5B</string>
-				<string>5FD7DAF58C678CF08753C2CF</string>
-				<string>1DEFBA6408892FCDF9CD0CBE</string>
-				<string>8FACD39921E226C45538D36D</string>
-				<string>40404A89F573301F72B104E7</string>
-				<string>3056646B71C947E10280766F</string>
-				<string>A141755FC4D21FE313A5FFBB</string>
-				<string>5AB0B3E647E47454DFA5B5D0</string>
-				<string>AF998711B2F0307CF53BE426</string>
-				<string>2483AD5B0E7A58A4213726FE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>738D74800431765D4619DD89</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-LoremIpsum-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73A7964DDB28B1010D2BBADD</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>75C781511AFB806BFE7E3B84</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>UIResponder+SLKAdditions.h</string>
-			<key>path</key>
-			<string>Source/Additions/UIResponder+SLKAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>789E488758B8458061450832</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6AB23B650927DAFEB1E0911C</string>
-				<string>C3E156C749D55510A96C99DE</string>
-				<string>7FB7F8E81ED6DBEC9FE67CD2</string>
-				<string>414B1D4986542762EBE5724D</string>
-				<string>1EACB7F5CD175594A6A8F3C8</string>
-				<string>70FE88017383F295009FC372</string>
-				<string>57163ED5AF931BCDEA2F7EA2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>path</key>
-			<string>Target Support Files/Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7BB09E5B0DAD515BF6658B79</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7D13EF769EF28E520E2EA41E</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-SlackTextViewController/Pods-SlackTextViewController-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>7D13EF769EF28E520E2EA41E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-SlackTextViewController-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7FB2A28E8E63BF5DAC6969BE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EDDF6F29F7F4DC1AD5969F3D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7FB7F8E81ED6DBEC9FE67CD2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>80632934078B19B08DDB5E5E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>738D74800431765D4619DD89</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-LoremIpsum/Pods-LoremIpsum-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>83ACF4F521A529D16BABF395</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>84D30FA4DCBE3035D622F868</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>8C1B84DACDB206401F48C291</string>
-				<string>0D746B13F5C4AE9D48AF9DEA</string>
-				<string>7FB2A28E8E63BF5DAC6969BE</string>
-				<string>36C9A6EB45792118AF223C70</string>
-				<string>B4AB6AB02E9EDD4E5945B2D0</string>
-				<string>95772DB7B6026FEDBEC93503</string>
-				<string>43B48171EE8F1ADC81693F05</string>
-				<string>2ED36F5D523634A20C27685B</string>
-				<string>D6DBBCF64DFF4BFFC3E7FE87</string>
-				<string>14794F6A897FAFA08EADBACD</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>85000EAEF831AA4CE6EB619D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0B69D1A854032ABEDDD24621</string>
-				<string>7D13EF769EF28E520E2EA41E</string>
-				<string>ADDD08A683A54E58905A3C67</string>
-				<string>FD6B033C27391D1046988229</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Examples/Pods/Target Support Files/Pods-SlackTextViewController</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8986B7DEAD88EB7796BEE683</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CBF0392BCE6BCBE3EEAF94CB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8B9B5AEF0435BA61A36D8C1E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E3E34E80876E1352ED418903</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8C1B84DACDB206401F48C291</key>
-		<dict>
-			<key>fileRef</key>
-			<string>97AEE76F92D8C3DA9FDC2D9E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8FACD39921E226C45538D36D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F884B933265352397FCA429E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>920BD825DD40FBFB3194C5D2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>LoremIpsum.h</string>
-			<key>path</key>
-			<string>LoremIpsum/LoremIpsum.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>95772DB7B6026FEDBEC93503</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DCF81591286B234885761247</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>966A5ABDF3EAB6C8CFB342CC</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>57163ED5AF931BCDEA2F7EA2</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>97AEE76F92D8C3DA9FDC2D9E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKInputAccessoryView.h</string>
-			<key>path</key>
-			<string>Source/Classes/SLKInputAccessoryView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>98FA7FBCBE6BE9D681418C5B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ADDD08A683A54E58905A3C67</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9978AE8EEA74043E81ECAFB2</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>B50D205813EC1B1D7675DF6E</string>
-			<key>buildPhases</key>
-			<array>
-				<string>5EC201BF62456DD04F2EDA3C</string>
-				<string>580CDF3D2ADC59D7876C55DB</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>110C248B665E30FB3A6CC0E5</string>
-				<string>174ECC3F2A7DB04D0B12A0BA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>productName</key>
-			<string>Pods</string>
-			<key>productReference</key>
-			<string>73A7964DDB28B1010D2BBADD</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>9C6779A4699AC850D8441CF1</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>83ACF4F521A529D16BABF395</string>
-				<string>185479967F501F27CCB77F6A</string>
-				<string>E3C920E0B1178B6F385B58B3</string>
-				<string>509B079B088E5C32FE3627C3</string>
-				<string>37402AC9C43922969CBB3D66</string>
-				<string>252C732A988DD78D0A3F4968</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A141755FC4D21FE313A5FFBB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5409018A02A1ECBC678D233E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A3DCE8364D505D2DBD968482</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7D13EF769EF28E520E2EA41E</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-SlackTextViewController/Pods-SlackTextViewController-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>ACC21FCA3CB9BE2674C87FE4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKUIConstants.h</string>
-			<key>path</key>
-			<string>Source/Additions/SLKUIConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ADDD08A683A54E58905A3C67</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-SlackTextViewController-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AF1156D3A6D77F7FC1146427</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>UIView+SLKAdditions.m</string>
-			<key>path</key>
-			<string>Source/Additions/UIView+SLKAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AF998711B2F0307CF53BE426</key>
-		<dict>
-			<key>fileRef</key>
-			<string>43024C52D057BF27FDB6B12E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B4AB6AB02E9EDD4E5945B2D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>26796A46D7611A091085716B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B50D205813EC1B1D7675DF6E</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>43C73CFF53FC3A2EB5078DF9</string>
-				<string>966A5ABDF3EAB6C8CFB342CC</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>B7219C0DACF4C14E521FF9D4</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>C0EC56AB75509C23DCB12425</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-LoremIpsum.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C3E156C749D55510A96C99DE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C5F59E253F8FE07410EB6634</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>SLKTextViewController.m</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTextViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C7BA5AE6F8CFE8DD4F5F52E8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>UIScrollView+SLKAdditions.h</string>
-			<key>path</key>
-			<string>Source/Additions/UIScrollView+SLKAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CBF0392BCE6BCBE3EEAF94CB</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>D0355FADDEB8E3F97DA68E56</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>738D74800431765D4619DD89</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-LoremIpsum/Pods-LoremIpsum-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>D22151F997D5E629EC2859E5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>7BB09E5B0DAD515BF6658B79</string>
-				<string>A3DCE8364D505D2DBD968482</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>D6DBBCF64DFF4BFFC3E7FE87</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C7BA5AE6F8CFE8DD4F5F52E8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DA87404005118305B5D9AA7F</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>1605EDC59602F5DA5E26D81E</string>
-				<string>B7219C0DACF4C14E521FF9D4</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>DCABAA9C1503D7BFA0FC46D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>920BD825DD40FBFB3194C5D2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DCF81591286B234885761247</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKTypingIndicatorView.h</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTypingIndicatorView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E32A5742B48F2DF95176F608</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0B577FC056DE5C5E8943C3E8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E3C920E0B1178B6F385B58B3</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F53A6C7D1D35DFC510CB8D91</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E3E34E80876E1352ED418903</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-LoremIpsum-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E41E2B16AD747D73700C2DA1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7FB7F8E81ED6DBEC9FE67CD2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5482AB14027B22416E5573E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CBF0392BCE6BCBE3EEAF94CB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E8BF4FDE1B5C188C2DF89776</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-SlackTextViewController.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>EBF4016A24EB31D4DFD41F25</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKTextInputbar.h</string>
-			<key>path</key>
-			<string>Source/Classes/SLKTextInputbar.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECAF5199780DD9A7948E7AF4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>UIView+SLKAdditions.h</string>
-			<key>path</key>
-			<string>Source/Additions/UIView+SLKAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EDDF6F29F7F4DC1AD5969F3D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>SLKTextView+SLKAdditions.h</string>
-			<key>path</key>
-			<string>Source/Additions/SLKTextView+SLKAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F10BBC109012E9D86E3FE50B</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>97AEE76F92D8C3DA9FDC2D9E</string>
-				<string>5CA11889F1446E3FD13358C9</string>
-				<string>EBF4016A24EB31D4DFD41F25</string>
-				<string>5E1BCD678DFF385194502B3A</string>
-				<string>6B97421C692BA2A16148F1A7</string>
-				<string>45A8D243F4C1E3EA2D8DAD0F</string>
-				<string>EDDF6F29F7F4DC1AD5969F3D</string>
-				<string>F884B933265352397FCA429E</string>
-				<string>26796A46D7611A091085716B</string>
-				<string>C5F59E253F8FE07410EB6634</string>
-				<string>DCF81591286B234885761247</string>
-				<string>5409018A02A1ECBC678D233E</string>
-				<string>ACC21FCA3CB9BE2674C87FE4</string>
-				<string>75C781511AFB806BFE7E3B84</string>
-				<string>43E948FF24C4D5A3C14D7B0B</string>
-				<string>C7BA5AE6F8CFE8DD4F5F52E8</string>
-				<string>43024C52D057BF27FDB6B12E</string>
-				<string>ECAF5199780DD9A7948E7AF4</string>
-				<string>AF1156D3A6D77F7FC1146427</string>
-				<string>85000EAEF831AA4CE6EB619D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>SlackTextViewController</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F53A6C7D1D35DFC510CB8D91</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CBF0392BCE6BCBE3EEAF94CB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F884B933265352397FCA429E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>SLKTextView+SLKAdditions.m</string>
-			<key>path</key>
-			<string>Source/Additions/SLKTextView+SLKAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FA790F678829AF1B76A86E3F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>C0EC56AB75509C23DCB12425</string>
-				<string>738D74800431765D4619DD89</string>
-				<string>E3E34E80876E1352ED418903</string>
-				<string>0221E66B4D6AB224183BB400</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Pods-LoremIpsum</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FD6B033C27391D1046988229</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-SlackTextViewController-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>68AF99EFDFA0F4D2B8A2D179</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		07DCED539CB32ADB33E26623 /* UIResponder+SLKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F104D04E48B514B2EDA45928 /* UIResponder+SLKAdditions.m */; };
+		08A5646171232B7A4CAAEF9C /* SLKInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B39C1D6E97FA16DCC5B70E /* SLKInputAccessoryView.m */; };
+		0A935C76C4D5ECC0D3DE47D5 /* Pods-SlackTextViewController-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D017D6946B68C64842D7FE0 /* Pods-SlackTextViewController-dummy.m */; };
+		0BE45E2168388B36663DCE34 /* LoremIpsum.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EB7F0F44E0F2999C4E70702 /* LoremIpsum.h */; };
+		12C029D7C000A9359C99E1A3 /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 436FE8AB6B57B4E127605D4B /* Pods-dummy.m */; };
+		17B35D5EAD9E13B336262F17 /* SLKTextView+SLKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D4A7E88CEC138B84081A019 /* SLKTextView+SLKAdditions.h */; };
+		1FB676B15569E668469B1465 /* SLKTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B89821E6A1F4AA7530639A4 /* SLKTextView.m */; };
+		2D2961507D0BF5259520AA4A /* SLKUIConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 49563224580594265329BAE1 /* SLKUIConstants.h */; };
+		3A0A47A340D1C69253E0F6DF /* Pods-LoremIpsum-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 49E49E9823C137FB77D91FDE /* Pods-LoremIpsum-dummy.m */; };
+		3B0D0A66A1C700B5069DEE06 /* SLKTypingIndicatorProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 21A1FF0414174976E7002D99 /* SLKTypingIndicatorProtocol.h */; };
+		3CB6E58015CB3E2EC0B98E8C /* SLKTypingIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F4241418D735A8A9B3CB5A5 /* SLKTypingIndicatorView.m */; };
+		528E080619D6C4D012A5FC2F /* SLKInputAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = C9B2A3E62445817C163E167D /* SLKInputAccessoryView.h */; };
+		5717B313A0DF222C0CEEEEF1 /* SLKTextViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = BF691046CE4CB9FBEC57F0A1 /* SLKTextViewController.h */; };
+		636836E8E9905658C3AD957C /* LoremIpsum.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C0D977643B48E045986734B /* LoremIpsum.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		648CDB2AD7ECF88FC1EEA39E /* SLKTextInputbar.m in Sources */ = {isa = PBXBuildFile; fileRef = BFA6C3DE6F728267054BCB45 /* SLKTextInputbar.m */; };
+		6E3862A82C4809F2125229BC /* SLKTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = E2C85D5121300F258BAA3AFA /* SLKTextView.h */; };
+		72A783C81D2522CE7FA43788 /* UIScrollView+SLKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E732072B25AC78BB42445E4 /* UIScrollView+SLKAdditions.h */; };
+		757663A9C4D928F9DF57C588 /* UIView+SLKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0F645D067315C02B840BEE /* UIView+SLKAdditions.h */; };
+		8C1AE0D21E878E0AA2DBCF9E /* SLKTextViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 48D7F7BB74694C4CE2050E6B /* SLKTextViewController.m */; };
+		B1602395C631ED99F15D0645 /* UIScrollView+SLKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E3BBC7577A764FCA1FC0088 /* UIScrollView+SLKAdditions.m */; };
+		B2833C814087F234C21E6C5A /* SLKTextInputbar.h in Headers */ = {isa = PBXBuildFile; fileRef = 69B71855CCEDC7AF671BA663 /* SLKTextInputbar.h */; };
+		B2F774BD1C899CDF6BDC5C77 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB52428C02FBCE72D8777D95 /* Foundation.framework */; };
+		D1FCD7DAB01E587770429E3E /* SLKTypingIndicatorView.h in Headers */ = {isa = PBXBuildFile; fileRef = 40EF00E2F63F4A5AB8B7B0CE /* SLKTypingIndicatorView.h */; };
+		D5E0CF9AE8D234A05A4F38B5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB52428C02FBCE72D8777D95 /* Foundation.framework */; };
+		DD0A8CE4452FD641BAA0F74F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB52428C02FBCE72D8777D95 /* Foundation.framework */; };
+		DFFC9720322F466BD686BB17 /* UIResponder+SLKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB78491DCFA59506794B7D53 /* UIResponder+SLKAdditions.h */; };
+		F11EA4056E845FF6B426E021 /* SLKTextView+SLKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 413207C9265E5F7FA8C6A5F7 /* SLKTextView+SLKAdditions.m */; };
+		F750ABD089567CD368F33694 /* UIView+SLKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 45AAEE0F82437B3B9C7E8A89 /* UIView+SLKAdditions.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		25EA5F889D1E8039DE78B788 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83E23CE5A140A2DC94562E73 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1EFE60AB3E90352AC7CD081F;
+			remoteInfo = "Pods-SlackTextViewController";
+		};
+		4974CD386E2FDE99C00E62C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83E23CE5A140A2DC94562E73 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D4BEA76D1F4EBE00E109B63;
+			remoteInfo = "Pods-LoremIpsum";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1FDFC4F4F964633F0F79273D /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		21A1FF0414174976E7002D99 /* SLKTypingIndicatorProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKTypingIndicatorProtocol.h; path = Source/Classes/SLKTypingIndicatorProtocol.h; sourceTree = "<group>"; };
+		2D58C131052D2431A2AE63B4 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.debug.xcconfig; sourceTree = "<group>"; };
+		30B4661930041CFBEF56D513 /* Pods-SlackTextViewController-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SlackTextViewController-prefix.pch"; sourceTree = "<group>"; };
+		32A0A0A820A654DC7AA10E29 /* libPods-SlackTextViewController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SlackTextViewController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		347ADD7352C128F91C4F36E0 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.release.xcconfig; sourceTree = "<group>"; };
+		38C20072A78CD4EFC24938BB /* libPods-LoremIpsum.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LoremIpsum.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3EB7F0F44E0F2999C4E70702 /* LoremIpsum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LoremIpsum.h; path = LoremIpsum/LoremIpsum.h; sourceTree = "<group>"; };
+		40EF00E2F63F4A5AB8B7B0CE /* SLKTypingIndicatorView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKTypingIndicatorView.h; path = Source/Classes/SLKTypingIndicatorView.h; sourceTree = "<group>"; };
+		413207C9265E5F7FA8C6A5F7 /* SLKTextView+SLKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "SLKTextView+SLKAdditions.m"; path = "Source/Additions/SLKTextView+SLKAdditions.m"; sourceTree = "<group>"; };
+		429BEC327934FC5990367136 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		436FE8AB6B57B4E127605D4B /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
+		45AAEE0F82437B3B9C7E8A89 /* UIView+SLKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+SLKAdditions.m"; path = "Source/Additions/UIView+SLKAdditions.m"; sourceTree = "<group>"; };
+		48D7F7BB74694C4CE2050E6B /* SLKTextViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SLKTextViewController.m; path = Source/Classes/SLKTextViewController.m; sourceTree = "<group>"; };
+		49563224580594265329BAE1 /* SLKUIConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKUIConstants.h; path = Source/Additions/SLKUIConstants.h; sourceTree = "<group>"; };
+		49E49E9823C137FB77D91FDE /* Pods-LoremIpsum-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-LoremIpsum-dummy.m"; sourceTree = "<group>"; };
+		5B89821E6A1F4AA7530639A4 /* SLKTextView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SLKTextView.m; path = Source/Classes/SLKTextView.m; sourceTree = "<group>"; };
+		5D017D6946B68C64842D7FE0 /* Pods-SlackTextViewController-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SlackTextViewController-dummy.m"; sourceTree = "<group>"; };
+		5E732072B25AC78BB42445E4 /* UIScrollView+SLKAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIScrollView+SLKAdditions.h"; path = "Source/Additions/UIScrollView+SLKAdditions.h"; sourceTree = "<group>"; };
+		5F4241418D735A8A9B3CB5A5 /* SLKTypingIndicatorView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SLKTypingIndicatorView.m; path = Source/Classes/SLKTypingIndicatorView.m; sourceTree = "<group>"; };
+		69B71855CCEDC7AF671BA663 /* SLKTextInputbar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKTextInputbar.h; path = Source/Classes/SLKTextInputbar.h; sourceTree = "<group>"; };
+		7282C3B6AA9AFF9073C7DF82 /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
+		7E3BBC7577A764FCA1FC0088 /* UIScrollView+SLKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIScrollView+SLKAdditions.m"; path = "Source/Additions/UIScrollView+SLKAdditions.m"; sourceTree = "<group>"; };
+		7E8EB567AC723F3D5F67AC09 /* Pods-LoremIpsum-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-LoremIpsum-prefix.pch"; sourceTree = "<group>"; };
+		8C0D977643B48E045986734B /* LoremIpsum.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LoremIpsum.m; path = LoremIpsum/LoremIpsum.m; sourceTree = "<group>"; };
+		8D4A7E88CEC138B84081A019 /* SLKTextView+SLKAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SLKTextView+SLKAdditions.h"; path = "Source/Additions/SLKTextView+SLKAdditions.h"; sourceTree = "<group>"; };
+		8FDF3EC0F1888E2782CB1B7A /* Pods-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-environment.h"; sourceTree = "<group>"; };
+		A21E961A2004B411CBEEF9D7 /* Pods-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-resources.sh"; sourceTree = "<group>"; };
+		A4BE0C637253FF526F807BBF /* Pods-LoremIpsum.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-LoremIpsum.xcconfig"; sourceTree = "<group>"; };
+		A5C7DE610BA49016A948FABE /* Pods-SlackTextViewController.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SlackTextViewController.xcconfig"; sourceTree = "<group>"; };
+		A7B39C1D6E97FA16DCC5B70E /* SLKInputAccessoryView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SLKInputAccessoryView.m; path = Source/Classes/SLKInputAccessoryView.m; sourceTree = "<group>"; };
+		B2F729A206AAFD9E1B734E00 /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
+		BF691046CE4CB9FBEC57F0A1 /* SLKTextViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKTextViewController.h; path = Source/Classes/SLKTextViewController.h; sourceTree = "<group>"; };
+		BFA6C3DE6F728267054BCB45 /* SLKTextInputbar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SLKTextInputbar.m; path = Source/Classes/SLKTextInputbar.m; sourceTree = "<group>"; };
+		C9B2A3E62445817C163E167D /* SLKInputAccessoryView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKInputAccessoryView.h; path = Source/Classes/SLKInputAccessoryView.h; sourceTree = "<group>"; };
+		D7E7870F08F6D6DCB6541460 /* Pods-LoremIpsum-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-LoremIpsum-Private.xcconfig"; sourceTree = "<group>"; };
+		DB52428C02FBCE72D8777D95 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		DC0F645D067315C02B840BEE /* UIView+SLKAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+SLKAdditions.h"; path = "Source/Additions/UIView+SLKAdditions.h"; sourceTree = "<group>"; };
+		E2C85D5121300F258BAA3AFA /* SLKTextView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SLKTextView.h; path = Source/Classes/SLKTextView.h; sourceTree = "<group>"; };
+		E8236A2F1AEFF2BBA49C6256 /* Pods-SlackTextViewController-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SlackTextViewController-Private.xcconfig"; sourceTree = "<group>"; };
+		F104D04E48B514B2EDA45928 /* UIResponder+SLKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIResponder+SLKAdditions.m"; path = "Source/Additions/UIResponder+SLKAdditions.m"; sourceTree = "<group>"; };
+		FB78491DCFA59506794B7D53 /* UIResponder+SLKAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIResponder+SLKAdditions.h"; path = "Source/Additions/UIResponder+SLKAdditions.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		370CD4CD7F43543F806B1CDF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD0A8CE4452FD641BAA0F74F /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CE2CAF29348D3A8997FC7D0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B2F774BD1C899CDF6BDC5C77 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DFE0A6A0ADEE3D74A4CDC30C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D5E0CF9AE8D234A05A4F38B5 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		09D83C25C5D189B909855830 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				429BEC327934FC5990367136 /* libPods.a */,
+				38C20072A78CD4EFC24938BB /* libPods-LoremIpsum.a */,
+				32A0A0A820A654DC7AA10E29 /* libPods-SlackTextViewController.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		17383DEE48326035FEFF96F2 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7282C3B6AA9AFF9073C7DF82 /* Pods-acknowledgements.markdown */,
+				B2F729A206AAFD9E1B734E00 /* Pods-acknowledgements.plist */,
+				436FE8AB6B57B4E127605D4B /* Pods-dummy.m */,
+				8FDF3EC0F1888E2782CB1B7A /* Pods-environment.h */,
+				A21E961A2004B411CBEEF9D7 /* Pods-resources.sh */,
+				2D58C131052D2431A2AE63B4 /* Pods.debug.xcconfig */,
+				347ADD7352C128F91C4F36E0 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			path = "Target Support Files/Pods";
+			sourceTree = "<group>";
+		};
+		279FC8FD331D33CBD469B9E7 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				A4BE0C637253FF526F807BBF /* Pods-LoremIpsum.xcconfig */,
+				D7E7870F08F6D6DCB6541460 /* Pods-LoremIpsum-Private.xcconfig */,
+				49E49E9823C137FB77D91FDE /* Pods-LoremIpsum-dummy.m */,
+				7E8EB567AC723F3D5F67AC09 /* Pods-LoremIpsum-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-LoremIpsum";
+			sourceTree = "<group>";
+		};
+		44729B0D7DA184A48035A483 /* LoremIpsum */ = {
+			isa = PBXGroup;
+			children = (
+				3EB7F0F44E0F2999C4E70702 /* LoremIpsum.h */,
+				8C0D977643B48E045986734B /* LoremIpsum.m */,
+				279FC8FD331D33CBD469B9E7 /* Support Files */,
+			);
+			path = LoremIpsum;
+			sourceTree = "<group>";
+		};
+		5381D50775F2DD2BD46039B4 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				17383DEE48326035FEFF96F2 /* Pods */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		59D1C8F8936C046745113CA9 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				DB52428C02FBCE72D8777D95 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		71AC1DF437825D41354A5F39 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				59D1C8F8936C046745113CA9 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		78DD5BF27BA4A31290465155 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7F912119901736C2B7251590 /* SlackTextViewController */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		7F912119901736C2B7251590 /* SlackTextViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C9B2A3E62445817C163E167D /* SLKInputAccessoryView.h */,
+				A7B39C1D6E97FA16DCC5B70E /* SLKInputAccessoryView.m */,
+				69B71855CCEDC7AF671BA663 /* SLKTextInputbar.h */,
+				BFA6C3DE6F728267054BCB45 /* SLKTextInputbar.m */,
+				E2C85D5121300F258BAA3AFA /* SLKTextView.h */,
+				5B89821E6A1F4AA7530639A4 /* SLKTextView.m */,
+				8D4A7E88CEC138B84081A019 /* SLKTextView+SLKAdditions.h */,
+				413207C9265E5F7FA8C6A5F7 /* SLKTextView+SLKAdditions.m */,
+				BF691046CE4CB9FBEC57F0A1 /* SLKTextViewController.h */,
+				48D7F7BB74694C4CE2050E6B /* SLKTextViewController.m */,
+				40EF00E2F63F4A5AB8B7B0CE /* SLKTypingIndicatorView.h */,
+				5F4241418D735A8A9B3CB5A5 /* SLKTypingIndicatorView.m */,
+				21A1FF0414174976E7002D99 /* SLKTypingIndicatorProtocol.h */,
+				49563224580594265329BAE1 /* SLKUIConstants.h */,
+				FB78491DCFA59506794B7D53 /* UIResponder+SLKAdditions.h */,
+				F104D04E48B514B2EDA45928 /* UIResponder+SLKAdditions.m */,
+				5E732072B25AC78BB42445E4 /* UIScrollView+SLKAdditions.h */,
+				7E3BBC7577A764FCA1FC0088 /* UIScrollView+SLKAdditions.m */,
+				DC0F645D067315C02B840BEE /* UIView+SLKAdditions.h */,
+				45AAEE0F82437B3B9C7E8A89 /* UIView+SLKAdditions.m */,
+				8AAE7539686DF1C49A04714D /* Support Files */,
+			);
+			name = SlackTextViewController;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		8AAE7539686DF1C49A04714D /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				A5C7DE610BA49016A948FABE /* Pods-SlackTextViewController.xcconfig */,
+				E8236A2F1AEFF2BBA49C6256 /* Pods-SlackTextViewController-Private.xcconfig */,
+				5D017D6946B68C64842D7FE0 /* Pods-SlackTextViewController-dummy.m */,
+				30B4661930041CFBEF56D513 /* Pods-SlackTextViewController-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "Examples/Pods/Target Support Files/Pods-SlackTextViewController";
+			sourceTree = "<group>";
+		};
+		BD7B242A749C28F8E9661B1F = {
+			isa = PBXGroup;
+			children = (
+				1FDFC4F4F964633F0F79273D /* Podfile */,
+				78DD5BF27BA4A31290465155 /* Development Pods */,
+				71AC1DF437825D41354A5F39 /* Frameworks */,
+				E529C3B6C66E7B57DE9E9463 /* Pods */,
+				09D83C25C5D189B909855830 /* Products */,
+				5381D50775F2DD2BD46039B4 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		E529C3B6C66E7B57DE9E9463 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				44729B0D7DA184A48035A483 /* LoremIpsum */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		092F1D9F114844F9D594D4CF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				528E080619D6C4D012A5FC2F /* SLKInputAccessoryView.h in Headers */,
+				B2833C814087F234C21E6C5A /* SLKTextInputbar.h in Headers */,
+				17B35D5EAD9E13B336262F17 /* SLKTextView+SLKAdditions.h in Headers */,
+				6E3862A82C4809F2125229BC /* SLKTextView.h in Headers */,
+				5717B313A0DF222C0CEEEEF1 /* SLKTextViewController.h in Headers */,
+				3B0D0A66A1C700B5069DEE06 /* SLKTypingIndicatorProtocol.h in Headers */,
+				D1FCD7DAB01E587770429E3E /* SLKTypingIndicatorView.h in Headers */,
+				2D2961507D0BF5259520AA4A /* SLKUIConstants.h in Headers */,
+				DFFC9720322F466BD686BB17 /* UIResponder+SLKAdditions.h in Headers */,
+				72A783C81D2522CE7FA43788 /* UIScrollView+SLKAdditions.h in Headers */,
+				757663A9C4D928F9DF57C588 /* UIView+SLKAdditions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		20DE7D384E7AF6F581899EF0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BE45E2168388B36663DCE34 /* LoremIpsum.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		1EFE60AB3E90352AC7CD081F /* Pods-SlackTextViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E38421B59CAE95AE03C17285 /* Build configuration list for PBXNativeTarget "Pods-SlackTextViewController" */;
+			buildPhases = (
+				850200C43EE4631302F931C3 /* Sources */,
+				DFE0A6A0ADEE3D74A4CDC30C /* Frameworks */,
+				092F1D9F114844F9D594D4CF /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-SlackTextViewController";
+			productName = "Pods-SlackTextViewController";
+			productReference = 32A0A0A820A654DC7AA10E29 /* libPods-SlackTextViewController.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		4D4BEA76D1F4EBE00E109B63 /* Pods-LoremIpsum */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 606E9F6BB9E862FBFC98B770 /* Build configuration list for PBXNativeTarget "Pods-LoremIpsum" */;
+			buildPhases = (
+				3236B73CC59935F037D6D399 /* Sources */,
+				3CE2CAF29348D3A8997FC7D0 /* Frameworks */,
+				20DE7D384E7AF6F581899EF0 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-LoremIpsum";
+			productName = "Pods-LoremIpsum";
+			productReference = 38C20072A78CD4EFC24938BB /* libPods-LoremIpsum.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		67C9B598BF2D6B4224520B8A /* Pods */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F5CC31BD2BF1404D8F1363FA /* Build configuration list for PBXNativeTarget "Pods" */;
+			buildPhases = (
+				F203BDDAFF7F514FC58EB717 /* Sources */,
+				370CD4CD7F43543F806B1CDF /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0D8991D2115F8D41B52171FA /* PBXTargetDependency */,
+				F4B5095F51B8447338E35C8C /* PBXTargetDependency */,
+			);
+			name = Pods;
+			productName = Pods;
+			productReference = 429BEC327934FC5990367136 /* libPods.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83E23CE5A140A2DC94562E73 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+			};
+			buildConfigurationList = D95AA2504B8CD5A6F83AACE0 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BD7B242A749C28F8E9661B1F;
+			productRefGroup = 09D83C25C5D189B909855830 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				67C9B598BF2D6B4224520B8A /* Pods */,
+				4D4BEA76D1F4EBE00E109B63 /* Pods-LoremIpsum */,
+				1EFE60AB3E90352AC7CD081F /* Pods-SlackTextViewController */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3236B73CC59935F037D6D399 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				636836E8E9905658C3AD957C /* LoremIpsum.m in Sources */,
+				3A0A47A340D1C69253E0F6DF /* Pods-LoremIpsum-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		850200C43EE4631302F931C3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A935C76C4D5ECC0D3DE47D5 /* Pods-SlackTextViewController-dummy.m in Sources */,
+				08A5646171232B7A4CAAEF9C /* SLKInputAccessoryView.m in Sources */,
+				648CDB2AD7ECF88FC1EEA39E /* SLKTextInputbar.m in Sources */,
+				F11EA4056E845FF6B426E021 /* SLKTextView+SLKAdditions.m in Sources */,
+				1FB676B15569E668469B1465 /* SLKTextView.m in Sources */,
+				8C1AE0D21E878E0AA2DBCF9E /* SLKTextViewController.m in Sources */,
+				3CB6E58015CB3E2EC0B98E8C /* SLKTypingIndicatorView.m in Sources */,
+				07DCED539CB32ADB33E26623 /* UIResponder+SLKAdditions.m in Sources */,
+				B1602395C631ED99F15D0645 /* UIScrollView+SLKAdditions.m in Sources */,
+				F750ABD089567CD368F33694 /* UIView+SLKAdditions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F203BDDAFF7F514FC58EB717 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				12C029D7C000A9359C99E1A3 /* Pods-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0D8991D2115F8D41B52171FA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-LoremIpsum";
+			target = 4D4BEA76D1F4EBE00E109B63 /* Pods-LoremIpsum */;
+			targetProxy = 4974CD386E2FDE99C00E62C8 /* PBXContainerItemProxy */;
+		};
+		F4B5095F51B8447338E35C8C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SlackTextViewController";
+			target = 1EFE60AB3E90352AC7CD081F /* Pods-SlackTextViewController */;
+			targetProxy = 25EA5F889D1E8039DE78B788 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		74FC0E9CC3C68288708907D0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				COPY_PHASE_STRIP = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		82C212FFE5148B3B3DAAA691 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2D58C131052D2431A2AE63B4 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		85F6050A478AC651ACDE13E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 347ADD7352C128F91C4F36E0 /* Pods.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9C433FA1D1D2467AEB108E64 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D7E7870F08F6D6DCB6541460 /* Pods-LoremIpsum-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-LoremIpsum/Pods-LoremIpsum-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		DA6F944EF887874DA1888C3E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E1F0E48AFEC113C57793E2FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E8236A2F1AEFF2BBA49C6256 /* Pods-SlackTextViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SlackTextViewController/Pods-SlackTextViewController-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EBE49C2E4F71E40AA9BC6F96 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D7E7870F08F6D6DCB6541460 /* Pods-LoremIpsum-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-LoremIpsum/Pods-LoremIpsum-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		EFCF0D5CFF32E541423090BC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E8236A2F1AEFF2BBA49C6256 /* Pods-SlackTextViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SlackTextViewController/Pods-SlackTextViewController-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		606E9F6BB9E862FBFC98B770 /* Build configuration list for PBXNativeTarget "Pods-LoremIpsum" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C433FA1D1D2467AEB108E64 /* Debug */,
+				EBE49C2E4F71E40AA9BC6F96 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D95AA2504B8CD5A6F83AACE0 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74FC0E9CC3C68288708907D0 /* Debug */,
+				DA6F944EF887874DA1888C3E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E38421B59CAE95AE03C17285 /* Build configuration list for PBXNativeTarget "Pods-SlackTextViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1F0E48AFEC113C57793E2FF /* Debug */,
+				EFCF0D5CFF32E541423090BC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F5CC31BD2BF1404D8F1363FA /* Build configuration list for PBXNativeTarget "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				82C212FFE5148B3B3DAAA691 /* Debug */,
+				85F6050A478AC651ACDE13E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83E23CE5A140A2DC94562E73 /* Project object */;
+}

--- a/Examples/Pods/Target Support Files/Pods/Pods-environment.h
+++ b/Examples/Pods/Target Support Files/Pods/Pods-environment.h
@@ -16,5 +16,5 @@
 #define COCOAPODS_POD_AVAILABLE_SlackTextViewController
 #define COCOAPODS_VERSION_MAJOR_SlackTextViewController 1
 #define COCOAPODS_VERSION_MINOR_SlackTextViewController 5
-#define COCOAPODS_VERSION_PATCH_SlackTextViewController 0
+#define COCOAPODS_VERSION_PATCH_SlackTextViewController 2
 

--- a/Source/Additions/UIView+SLKAdditions.h
+++ b/Source/Additions/UIView+SLKAdditions.h
@@ -28,6 +28,8 @@
  */
 - (void)slk_animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations;
 
+- (void)slk_animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion;
+
 /**
  Animates the view's constraints by calling layoutIfNeeded.
  
@@ -36,7 +38,7 @@
  @param options A mask of options indicating how you want to perform the animations.
  @param animations An additional block for custom animations.
  */
-- (void)slk_animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations;
+- (void)slk_animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion;
 
 /**
  Returns the view constraints matching a specific layout attribute (top, bottom, left, right, leading, trailing, etc.)

--- a/Source/Additions/UIView+SLKAdditions.m
+++ b/Source/Additions/UIView+SLKAdditions.m
@@ -22,11 +22,16 @@
 
 - (void)slk_animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations
 {
-    NSTimeInterval duration = bounce ? 0.5 : 0.2;
-    [self slk_animateLayoutIfNeededWithDuration:duration bounce:bounce options:options animations:animations];
+    [self slk_animateLayoutIfNeededWithBounce:bounce options:options animations:animations completion:NULL];
 }
 
-- (void)slk_animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations
+- (void)slk_animateLayoutIfNeededWithBounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion
+{
+    NSTimeInterval duration = bounce ? 0.5 : 0.2;
+    [self slk_animateLayoutIfNeededWithDuration:duration bounce:bounce options:options animations:animations completion:completion];
+}
+
+- (void)slk_animateLayoutIfNeededWithDuration:(NSTimeInterval)duration bounce:(BOOL)bounce options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion
 {
     if (bounce) {
         [UIView animateWithDuration:duration
@@ -41,7 +46,7 @@
                                  animations();
                              }
                          }
-                         completion:NULL];
+                         completion:completion];
     }
     else {
         [UIView animateWithDuration:duration
@@ -49,12 +54,12 @@
                             options:options
                          animations:^{
                              [self layoutIfNeeded];
-                             
+
                              if (animations) {
                                  animations();
                              }
                          }
-                         completion:NULL];
+                         completion:completion];
     }
 }
 

--- a/Source/Classes/SLKTextView.m
+++ b/Source/Classes/SLKTextView.m
@@ -422,14 +422,6 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 }
 
 
-#pragma mark - UITextInputTraits Overrides
-
-- (void)insertText:(NSString *)text
-{
-    [super insertText:text];
-}
-
-
 #pragma mark - UIResponder Overrides
 
 - (BOOL)canBecomeFirstResponder

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -59,7 +59,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /** The bottom toolbar containing a text view and buttons. */
 @property (nonatomic, readonly) SLKTextInputbar *textInputbar;
 
-/** The typing indicator used to display user names horizontally. */
+/** The default typing indicator used to display user names horizontally. */
 @property (nonatomic, readonly) SLKTypingIndicatorView *typingIndicatorView;
 
 /**

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -18,8 +18,9 @@
 #import <UIKit/UIKit.h>
 
 #import "SLKTextInputbar.h"
-#import "SLKTypingIndicatorView.h"
 #import "SLKTextView.h"
+#import "SLKTypingIndicatorView.h"
+#import "SLKTypingIndicatorProtocol.h"
 
 #import "SLKTextView+SLKAdditions.h"
 #import "UIScrollView+SLKAdditions.h"
@@ -60,6 +61,9 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 
 /** The typing indicator used to display user names horizontally. */
 @property (nonatomic, readonly) SLKTypingIndicatorView *typingIndicatorView;
+
+/** The custom typing indicator view. Will be a kind of SLKTypingIndicatorView by default. Override by calling -registerClassForTypingIndicatorView: during init */
+@property (nonatomic, readonly) UIView <SLKTypingIndicatorProtocol> *typingIndicatorCustomView;
 
 /** A single tap gesture used to dismiss the keyboard. */
 @property (nonatomic, readonly) UIGestureRecognizer *singleTapGesture;
@@ -267,9 +271,10 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  Verifies that the typing indicator view should be shown. Default is YES, if meeting some requierements.
  You can override this method to perform additional tasks. You SHOULD call super to inherit some conditionals.
  
- @return YES if the typing indicator view should be shown.
+ @return YES if the typing indicator view should be presented.
  */
-- (BOOL)canShowTypeIndicator;
+- (BOOL)canShowTypeIndicator DEPRECATED_MSG_ATTRIBUTE("Use -canShowTypingIndicator");
+- (BOOL)canShowTypingIndicator;
 
 /**
  Notifies the view controller when the user has shaked the device for undoing text typing.
@@ -362,7 +367,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 
 /**
  Verifies that the autocompletion view should be shown. Default is NO.
- To enabled autocompletion, MUST override this method to perform additional tasks, before the autocompletion view is shown (i.e. populating the data source).
+ To enabled autocompletion, you MUST override this method to perform additional tasks, before the autocompletion view is shown (i.e. populating the data source).
  
  @return YES if the autocompletion view should be shown.
  */
@@ -442,9 +447,18 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  Registers a class for customizing the behavior and appearance of the text view.
  You need to call this method inside of any initialization method.
  
- @param textViewClass A SLKTextView subclass.
+ @param aClass A SLKTextView subclass.
  */
-- (void)registerClassForTextView:(Class)textViewClass;
+- (void)registerClassForTextView:(Class)aClass;
+
+/**
+ Registers a class for customizing the behavior and appearance of the typing indicator view.
+ You need to call this method inside of any initialization method.
+ Make sure to conform to SLKTypingIndicatorProtocol and implement the required methods.
+
+ @param aClass A UIView subclass conforming to the SLKTypingIndicatorProtocol.
+ */
+- (void)registerClassForTypingIndicatorView:(Class)aClass;
 
 
 #pragma mark - Delegate Methods Requiring Super

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -62,8 +62,12 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /** The typing indicator used to display user names horizontally. */
 @property (nonatomic, readonly) SLKTypingIndicatorView *typingIndicatorView;
 
-/** The custom typing indicator view. Will be a kind of SLKTypingIndicatorView by default. Override by calling -registerClassForTypingIndicatorView: during init */
-@property (nonatomic, readonly) UIView <SLKTypingIndicatorProtocol> *typingIndicatorCustomView;
+/**
+ The custom typing indicator view. Default is kind of SLKTypingIndicatorView.
+ To customize the typing indicator view, you will need to call -registerClassForTypingIndicatorView: nside of any initialization method.
+ To interact with it directly, you will need to cast the return value of -typingIndicatorProxyView to the appropriate type.
+ */
+@property (nonatomic, readonly) UIView <SLKTypingIndicatorProtocol> *typingIndicatorProxyView;
 
 /** A single tap gesture used to dismiss the keyboard. */
 @property (nonatomic, readonly) UIGestureRecognizer *singleTapGesture;

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -76,7 +76,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 @synthesize tableView = _tableView;
 @synthesize collectionView = _collectionView;
 @synthesize scrollView = _scrollView;
-@synthesize typingIndicatorCustomView = _typingIndicatorCustomView;
+@synthesize typingIndicatorProxyView = _typingIndicatorProxyView;
 @synthesize textInputbar = _textInputbar;
 @synthesize autoCompletionView = _autoCompletionView;
 @synthesize autoCompleting = _autoCompleting;
@@ -322,24 +322,24 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     return _textInputbar;
 }
 
-- (UIView <SLKTypingIndicatorProtocol> *)typingIndicatorCustomView
+- (UIView <SLKTypingIndicatorProtocol> *)typingIndicatorProxyView
 {
-    if (!_typingIndicatorCustomView)
+    if (!_typingIndicatorProxyView)
     {
         Class class = self.typingIndicatorViewClass ? : [SLKTypingIndicatorView class];
         
-        _typingIndicatorCustomView = [[class alloc] init];
-        _typingIndicatorCustomView.translatesAutoresizingMaskIntoConstraints = NO;
-        _typingIndicatorCustomView.hidden = YES;
+        _typingIndicatorProxyView = [[class alloc] init];
+        _typingIndicatorProxyView.translatesAutoresizingMaskIntoConstraints = NO;
+        _typingIndicatorProxyView.hidden = YES;
         
-        [_typingIndicatorCustomView addObserver:self forKeyPath:NSStringFromSelector(@selector(isVisible)) options:NSKeyValueObservingOptionNew context:nil];
+        [_typingIndicatorProxyView addObserver:self forKeyPath:NSStringFromSelector(@selector(isVisible)) options:NSKeyValueObservingOptionNew context:nil];
     }
-    return _typingIndicatorCustomView;
+    return _typingIndicatorProxyView;
 }
 
 - (SLKTypingIndicatorView *)typingIndicatorView
 {
-    return (SLKTypingIndicatorView *)self.typingIndicatorCustomView;
+    return (SLKTypingIndicatorView *)self.typingIndicatorProxyView;
 }
 
 - (BOOL)isExternalKeyboardDetected
@@ -1967,8 +1967,8 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     _textInputbar = nil;
     _textViewClass = nil;
     
-    [_typingIndicatorCustomView removeObserver:self forKeyPath:NSStringFromSelector(@selector(isVisible))];
-    _typingIndicatorCustomView = nil;
+    [_typingIndicatorProxyView removeObserver:self forKeyPath:NSStringFromSelector(@selector(isVisible))];
+    _typingIndicatorProxyView = nil;
     _typingIndicatorViewClass = nil;
     
     _registeredPrefixes = nil;

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -332,7 +332,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
         _typingIndicatorProxyView.translatesAutoresizingMaskIntoConstraints = NO;
         _typingIndicatorProxyView.hidden = YES;
         
-        [_typingIndicatorProxyView addObserver:self forKeyPath:NSStringFromSelector(@selector(isVisible)) options:NSKeyValueObservingOptionNew context:nil];
+        [_typingIndicatorProxyView addObserver:self forKeyPath:@"visible" options:NSKeyValueObservingOptionNew context:nil];
     }
     return _typingIndicatorProxyView;
 }
@@ -1061,7 +1061,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if ([object conformsToProtocol:@protocol(SLKTypingIndicatorProtocol)] && [keyPath isEqualToString:NSStringFromSelector(@selector(isVisible))]) {
+    if ([object conformsToProtocol:@protocol(SLKTypingIndicatorProtocol)] && [keyPath isEqualToString:@"visible"]) {
         [self slk_willShowOrHideTypeIndicatorView:object];
     }
     else {
@@ -1970,7 +1970,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     _textInputbar = nil;
     _textViewClass = nil;
     
-    [_typingIndicatorProxyView removeObserver:self forKeyPath:NSStringFromSelector(@selector(isVisible))];
+    [_typingIndicatorProxyView removeObserver:self forKeyPath:@"visible"];
     _typingIndicatorProxyView = nil;
     _typingIndicatorViewClass = nil;
     

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -176,7 +176,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 
     [self.view addSubview:self.scrollViewProxy];
     [self.view addSubview:self.autoCompletionView];
-    [self.view addSubview:self.typingIndicatorView];
+    [self.view addSubview:self.typingIndicatorProxyView];
     [self.view addSubview:self.textInputbar];
 
     [self slk_setupViewConstraints];
@@ -339,7 +339,10 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 
 - (SLKTypingIndicatorView *)typingIndicatorView
 {
-    return (SLKTypingIndicatorView *)self.typingIndicatorProxyView;
+    if ([_typingIndicatorProxyView isKindOfClass:[SLKTypingIndicatorView class]]) {
+        return (SLKTypingIndicatorView *)self.typingIndicatorProxyView;
+    }
+    return nil;
 }
 
 - (BOOL)isExternalKeyboardDetected
@@ -1796,7 +1799,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 {
     NSDictionary *views = @{@"scrollView": self.scrollViewProxy,
                             @"autoCompletionView": self.autoCompletionView,
-                            @"typingIndicatorView": self.typingIndicatorView,
+                            @"typingIndicatorView": self.typingIndicatorProxyView,
                             @"textInputbar": self.textInputbar,
                             };
     
@@ -1808,7 +1811,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     
     self.scrollViewHC = [self.view slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.scrollViewProxy secondItem:nil];
     self.autoCompletionViewHC = [self.view slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.autoCompletionView secondItem:nil];
-    self.typingIndicatorViewHC = [self.view slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.typingIndicatorView secondItem:nil];
+    self.typingIndicatorViewHC = [self.view slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.typingIndicatorProxyView secondItem:nil];
     self.textInputbarHC = [self.view slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.textInputbar secondItem:nil];
     self.keyboardHC = [self.view slk_constraintForAttribute:NSLayoutAttributeBottom firstItem:self.view secondItem:self.textInputbar];
     

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -255,7 +255,6 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     {
         _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:style];
         _tableView.translatesAutoresizingMaskIntoConstraints = NO;
-        _tableView.backgroundColor = [UIColor whiteColor];
         _tableView.scrollsToTop = YES;
         _tableView.dataSource = self;
         _tableView.delegate = self;
@@ -269,7 +268,6 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     {
         _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
         _collectionView.translatesAutoresizingMaskIntoConstraints = NO;
-        _collectionView.backgroundColor = [UIColor whiteColor];
         _collectionView.scrollsToTop = YES;
         _collectionView.dataSource = self;
         _collectionView.delegate = self;

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -1312,7 +1312,7 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
         return;
     }
     
-    CGFloat systemLayoutSizeHeight = [typingIndicatorView systemLayoutSizeFittingSize:CGSizeZero].height;
+    CGFloat systemLayoutSizeHeight = [typingIndicatorView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
     CGFloat height = typingIndicatorView.isVisible ? systemLayoutSizeHeight : 0.0;
     
     self.typingIndicatorViewHC.constant = height;

--- a/Source/Classes/SLKTypingIndicatorProtocol.h
+++ b/Source/Classes/SLKTypingIndicatorProtocol.h
@@ -16,6 +16,10 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ Generic protocol needed when customizing your own typing indicator view.
+ Since SLKTextViewController depends of 'isVisible' internally, you will MUST adopt this property in your own typing indicator view implementation.
+ */
 @protocol SLKTypingIndicatorProtocol <NSObject>
 @required
 

--- a/Source/Classes/SLKTypingIndicatorProtocol.h
+++ b/Source/Classes/SLKTypingIndicatorProtocol.h
@@ -16,25 +16,16 @@
 
 #import <Foundation/Foundation.h>
 
-/**
- Generic protocol needed when customizing your own typing indicator view.
- SLKTextViewController depends of the 'isVisible' property internally, to detect with KVO its changes and update the typing indicator view's constraints automatically.
- Because of this, you MUST conform to this protocol and implement the required methods.
- */
+/** Generic protocol needed when customizing your own typing indicator view. */
 @protocol SLKTypingIndicatorProtocol <NSObject>
 @required
 
-/** Returns YES if the indicator is visible. */
-@property (nonatomic, getter = isVisible) BOOL visible;
-
 /**
- Updates the 'visible' state.
- To enable the typing indicator, you MUST override this method and implement key-value observer compliance manually,
- using the -willChangeValueForKey: and -didChangeValueForKey: methods.
- 
- @return YES if the indicator view is visible.
+ Returns YES if the indicator is visible.
+ SLKTextViewController depends on this property internally, by observing its value changes to update the typing indicator view's constraints automatically.
+ You can simply @synthesize this property to make it KVO compliant, or override its setter method and wrap its implementation with -willChangeValueForKey: and -didChangeValueForKey: methods, for more complex KVO compliance.
  */
-- (void)setVisible:(BOOL)visible;
+@property (nonatomic, getter = isVisible) BOOL visible;
 
 @optional
 

--- a/Source/Classes/SLKTypingIndicatorProtocol.h
+++ b/Source/Classes/SLKTypingIndicatorProtocol.h
@@ -27,13 +27,6 @@
  */
 @property (nonatomic, getter = isVisible) BOOL visible;
 
-/**
- Returns the natural size for the receiving view, considering only properties of the view itself.
- SLKTextViewController uses Auto-Layout internally, so this API is the most appropriate way to update the view dimensions dynamically.
- You can return UIViewNoIntrinsicMetric for any intrinsic size of a given dimension.
- */
-- (CGSize)intrinsicContentSize;
-
 @optional
 
 /**

--- a/Source/Classes/SLKTypingIndicatorProtocol.h
+++ b/Source/Classes/SLKTypingIndicatorProtocol.h
@@ -27,6 +27,13 @@
  */
 @property (nonatomic, getter = isVisible) BOOL visible;
 
+/**
+ Returns the natural size for the receiving view, considering only properties of the view itself.
+ SLKTextViewController uses Auto-Layout internally, so this API is the most appropriate way to update the view dimensions dynamically.
+ You can return UIViewNoIntrinsicMetric for any intrinsic size of a given dimension.
+ */
+- (CGSize)intrinsicContentSize;
+
 @optional
 
 /**

--- a/Source/Classes/SLKTypingIndicatorProtocol.h
+++ b/Source/Classes/SLKTypingIndicatorProtocol.h
@@ -18,7 +18,8 @@
 
 /**
  Generic protocol needed when customizing your own typing indicator view.
- Since SLKTextViewController depends of 'isVisible' internally, you will MUST adopt this property in your own typing indicator view implementation.
+ SLKTextViewController depends of the 'isVisible' property internally, to detect with KVO its changes and update the typing indicator view's constraints automatically.
+ Because of this, you MUST conform to this protocol and implement the required methods.
  */
 @protocol SLKTypingIndicatorProtocol <NSObject>
 @required
@@ -31,7 +32,7 @@
  To enable the typing indicator, you MUST override this method and implement key-value observer compliance manually,
  using the -willChangeValueForKey: and -didChangeValueForKey: methods.
  
- @return YES if the autocompletion view should be shown.
+ @return YES if the indicator view is visible.
  */
 - (void)setVisible:(BOOL)visible;
 

--- a/Source/Classes/SLKTypingIndicatorProtocol.h
+++ b/Source/Classes/SLKTypingIndicatorProtocol.h
@@ -14,16 +14,28 @@
 //   limitations under the License.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
-/** @name UIResponder additional features used for SlackTextViewController. */
-@interface UIResponder (SLKAdditions)
+@protocol SLKTypingIndicatorProtocol <NSObject>
+@required
+
+/** Returns YES if the indicator is visible. */
+@property (nonatomic, getter = isVisible) BOOL visible;
 
 /**
- Returns the current first responder object.
+ Updates the 'visible' state.
+ To enable the typing indicator, you MUST override this method and implement key-value observer compliance manually,
+ using the -willChangeValueForKey: and -didChangeValueForKey: methods.
  
- @return A UIResponder instance.
+ @return YES if the autocompletion view should be shown.
  */
-+ (instancetype)slk_currentFirstResponder;
+- (void)setVisible:(BOOL)visible;
+
+@optional
+
+/**
+ Dismisses the indicator view.
+ */
+- (void)dismissIndicator;
 
 @end

--- a/Source/Classes/SLKTypingIndicatorView.h
+++ b/Source/Classes/SLKTypingIndicatorView.h
@@ -15,24 +15,16 @@
 //
 
 #import <UIKit/UIKit.h>
-
-UIKIT_EXTERN NSString * const SLKTypingIndicatorViewWillShowNotification;
-UIKIT_EXTERN NSString * const SLKTypingIndicatorViewWillHideNotification;
+#import "SLKTypingIndicatorProtocol.h"
 
 /** @name A custom view to display an indicator of users typing. */
-@interface SLKTypingIndicatorView : UIView
+@interface SLKTypingIndicatorView : UIView <SLKTypingIndicatorProtocol>
 
 /** The amount of time a name should keep visible. If is zero, the indicator will not remove nor disappear automatically. Default is 6.0 seconds*/
 @property (nonatomic, readwrite) NSTimeInterval interval;
 
-/** If YES, the user can dismiss the indicator by tapping on it. Default is YES. */
+/** If YES, the user can dismiss the indicator by tapping on it. Default is NO. */
 @property (nonatomic, readwrite) BOOL canResignByTouch;
-
-/** Returns YES if the indicator is visible. */
-@property (nonatomic, readwrite, getter = isVisible) BOOL visible;
-
-/** The appropriate height of the view. */
-@property (nonatomic, readonly) CGFloat height;
 
 /** The color of the text. Default is grayColor. */
 @property (nonatomic, strong) UIColor *textColor;
@@ -69,10 +61,5 @@ UIKIT_EXTERN NSString * const SLKTypingIndicatorViewWillHideNotification;
  @param username The user name string.
  */
 - (void)removeUsername:(NSString *)username;
-
-/**
- Dismisses the indicator view.
- */
-- (void)dismissIndicator;
 
 @end

--- a/Source/Classes/SLKTypingIndicatorView.m
+++ b/Source/Classes/SLKTypingIndicatorView.m
@@ -77,6 +77,11 @@
 
 #pragma mark - SLKTypingIndicatorProtocol
 
+- (CGSize)intrinsicContentSize
+{
+    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
+}
+
 - (void)setVisible:(BOOL)visible
 {
     // Skip when updating the same value, specially to avoid inovking KVO unnecessary
@@ -97,21 +102,15 @@
     [self didChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
 }
 
+- (void)dismissIndicator
+{
+    if (self.isVisible) {
+        self.visible = NO;
+    }
+}
+
 
 #pragma mark - Getters
-
-- (CGSize)intrinsicContentSize
-{
-    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
-}
-
-- (CGFloat)height
-{
-    CGFloat height = self.textFont.lineHeight;
-    height += self.contentInset.top;
-    height += self.contentInset.bottom;
-    return height;
-}
 
 - (UILabel *)textLabel
 {
@@ -164,6 +163,14 @@
     }
     
     return attributedString;
+}
+
+- (CGFloat)height
+{
+    CGFloat height = self.textFont.lineHeight;
+    height += self.contentInset.top;
+    height += self.contentInset.bottom;
+    return height;
 }
 
 
@@ -244,13 +251,6 @@
         self.textLabel.attributedText = [self attributedString];
     }
     else {
-        self.visible = NO;
-    }
-}
-
-- (void)dismissIndicator
-{
-    if (self.isVisible) {
         self.visible = NO;
     }
 }

--- a/Source/Classes/SLKTypingIndicatorView.m
+++ b/Source/Classes/SLKTypingIndicatorView.m
@@ -18,9 +18,6 @@
 #import "UIView+SLKAdditions.h"
 #import "SLKUIConstants.h"
 
-NSString * const SLKTypingIndicatorViewWillShowNotification =   @"SLKTypingIndicatorViewWillShowNotification";
-NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndicatorViewWillHideNotification";
-
 #define SLKTypingIndicatorViewIdentifier    [NSString stringWithFormat:@"%@.%@", SLKTextViewControllerDomain, NSStringFromClass([self class])]
 
 @interface SLKTypingIndicatorView ()
@@ -38,6 +35,7 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
 @end
 
 @implementation SLKTypingIndicatorView
+@synthesize visible = _visible;
 
 #pragma mark - Initializer
 
@@ -59,8 +57,10 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
 
 - (void)slk_commonInit
 {
+    self.backgroundColor = [UIColor whiteColor];
+    
     self.interval = 6.0;
-    self.canResignByTouch = YES;
+    self.canResignByTouch = NO;
     self.usernames = [NSMutableArray new];
     self.timers = [NSMutableArray new];
     
@@ -69,28 +69,49 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     self.highlightFont = [UIFont boldSystemFontOfSize:12.0];
     self.contentInset = UIEdgeInsetsMake(10.0, 40.0, 10.0, 10.0);
     
-    self.backgroundColor = [UIColor whiteColor];
-    
     [self addSubview:self.textLabel];
     
     [self slk_setupConstraints];
 }
 
 
-#pragma mark - UIView Overrides
+#pragma mark - SLKTypingIndicatorProtocol
+
+- (void)setVisible:(BOOL)visible
+{
+    // Skip when updating the same value, specially to avoid inovking KVO unnecessary
+    if (visible == self.isVisible) {
+        return;
+    }
+    
+    // Required implementation for key-value observer compliance
+    [self willChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
+    
+    _visible = visible;
+    
+    if (!visible) {
+        [self slk_invalidateTimers];
+    }
+
+    // Required implementation for key-value observer compliance
+    [self didChangeValueForKey:NSStringFromSelector(@selector(isVisible))];
+}
+
+
+#pragma mark - Getters
 
 - (CGSize)intrinsicContentSize
 {
     return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
 }
 
-+ (BOOL)requiresConstraintBasedLayout
+- (CGFloat)height
 {
-    return YES;
+    CGFloat height = self.textFont.lineHeight;
+    height += self.contentInset.top;
+    height += self.contentInset.bottom;
+    return height;
 }
-
-
-#pragma mark - Getters
 
 - (UILabel *)textLabel
 {
@@ -99,8 +120,8 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
         _textLabel = [UILabel new];
         _textLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _textLabel.backgroundColor = [UIColor clearColor];
+        _textLabel.contentMode = UIViewContentModeTopLeft;
         _textLabel.userInteractionEnabled = NO;
-        _textLabel.hidden = YES;
     }
     return _textLabel;
 }
@@ -145,52 +166,8 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     return attributedString;
 }
 
-- (CGFloat)height
-{
-    CGFloat height = self.textFont.lineHeight;
-    height += self.contentInset.top;
-    height += self.contentInset.bottom;
-    return height;
-}
-
-
-- (NSTimer *)slk_timerWithIdentifier:(NSString *)identifier
-{
-    for (NSTimer *timer in self.timers) {
-        if ([identifier isEqualToString:[timer.userInfo objectForKey:SLKTypingIndicatorViewIdentifier]]) {
-            return timer;
-        }
-    }
-    return nil;
-}
-
 
 #pragma mark - Setters
-
-- (void)setVisible:(BOOL)visible
-{
-    if (visible == self.visible) {
-        return;
-    }
-    
-    NSString *notificationName = visible ? SLKTypingIndicatorViewWillShowNotification : SLKTypingIndicatorViewWillHideNotification;
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:self];
-    
-    if (visible) {
-        self.textLabel.hidden = NO;
-    }
-    else {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            self.textLabel.hidden = YES;
-        });
-    }
-    
-    _visible = visible;
-    
-    if (!visible) {
-        [self slk_cleanAll];
-    }
-}
 
 - (void)setContentInset:(UIEdgeInsets)insets
 {
@@ -206,6 +183,19 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     _contentInset = insets;
     
     [self slk_updateConstraintConstants];
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+    if (self.isHidden == hidden) {
+        return;
+    }
+    
+    if (hidden) {
+        [self slk_prepareForReuse];
+    }
+    
+    [super setHidden:hidden];
 }
 
 
@@ -239,9 +229,7 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     
     self.textLabel.attributedText = [self attributedString];
     
-    if (!self.isVisible) {
-        [self setVisible:YES];
-    }
+    self.visible = YES;
 }
 
 - (void)removeUsername:(NSString *)username
@@ -255,15 +243,15 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     if (self.usernames.count > 0) {
         self.textLabel.attributedText = [self attributedString];
     }
-    else if (self.isVisible) {
-        [self setVisible:NO];
+    else {
+        self.visible = NO;
     }
 }
 
 - (void)dismissIndicator
 {
     if (self.isVisible) {
-        [self setVisible:NO];
+        self.visible = NO;
     }
 }
 
@@ -276,6 +264,16 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     
     [self removeUsername:identifier];
     [self slk_invalidateTimer:timer];
+}
+
+- (NSTimer *)slk_timerWithIdentifier:(NSString *)identifier
+{
+    for (NSTimer *timer in self.timers) {
+        if ([identifier isEqualToString:[timer.userInfo objectForKey:SLKTypingIndicatorViewIdentifier]]) {
+            return timer;
+        }
+    }
+    return nil;
 }
 
 - (void)slk_invalidateTimer:(NSTimer *)timer
@@ -296,7 +294,7 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     [self.timers removeAllObjects];
 }
 
-- (void)slk_cleanAll
+- (void)slk_prepareForReuse
 {
     [self slk_invalidateTimers];
     
@@ -304,9 +302,6 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
     
     [self.usernames removeAllObjects];
 }
-
-
-#pragma mark - View Auto-Layout
 
 - (void)slk_setupConstraints
 {
@@ -330,17 +325,18 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
 
 #pragma mark - Hit Testing
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    UIView *view = [super hitTest:point withEvent:event];
+    [super touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
     
-    if ([view isEqual:self]) {
-        if (self.isVisible && self.canResignByTouch) {
-            [self setVisible:NO];
-        }
-        return view;
+    if (self.canResignByTouch) {
+        [self dismissIndicator];
     }
-    return view;
 }
 
 
@@ -348,7 +344,7 @@ NSString * const SLKTypingIndicatorViewWillHideNotification =   @"SLKTypingIndic
 
 - (void)dealloc
 {
-    [self slk_cleanAll];
+    [self slk_prepareForReuse];
     
     _textLabel = nil;
     _usernames = nil;

--- a/Source/Classes/SLKTypingIndicatorView.m
+++ b/Source/Classes/SLKTypingIndicatorView.m
@@ -77,11 +77,6 @@
 
 #pragma mark - SLKTypingIndicatorProtocol
 
-- (CGSize)intrinsicContentSize
-{
-    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
-}
-
 - (void)setVisible:(BOOL)visible
 {
     // Skip when updating the same value, specially to avoid inovking KVO unnecessary
@@ -163,6 +158,11 @@
     }
     
     return attributedString;
+}
+
+- (CGSize)intrinsicContentSize
+{
+    return CGSizeMake(UIViewNoIntrinsicMetric, [self height]);
 }
 
 - (CGFloat)height


### PR DESCRIPTION
*Inspired from @sveinhal's implementation in #202.*

It now uses KVO internally, observing the `visible` propery's changes to properly update the view constraints constants and animately present the typing indicator view.
By simply conforming to `SLKTypingIndicatorProtocol` required methods, it should be very easy to add any sort of custom typing indicator view.

I have added a custom typing indicator view to the sample project:
![image](https://cloud.githubusercontent.com/assets/590579/8398714/af0f39b0-1dd0-11e5-9602-456ffc5f77d0.png)

PS: Thanks @sveinhal for taking the initiative to do this! I felt the need to refactor your implementation for a more friendly approach. Observing the `hidden` property wasn't enough, since it would force the view to hide when dismissing the typing indicator. I have also taken the time to refactor and improve other related to logic to the default typing indicator view.
**This update should be backwards compatible, but might still need some testing before merging.**