### PR TITLE
Adds support for registering longer auto-completion prefixes

### DIFF
--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -128,7 +128,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 #endif
     
     [self.autoCompletionView registerClass:[MessageTableViewCell class] forCellReuseIdentifier:AutoCompletionCellIdentifier];
-    [self registerPrefixesForAutoCompletion:@[@"@", @"#", @":"]];
+    [self registerPrefixesForAutoCompletion:@[@"@", @"#", @":", @"+:"]];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -379,7 +379,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     else if ([prefix isEqualToString:@"#"] && word.length > 0) {
         array = [self.channels filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self BEGINSWITH[c] %@", word]];
     }
-    else if ([prefix isEqualToString:@":"] && word.length > 1) {
+    else if (([prefix isEqualToString:@":"] || [prefix isEqualToString:@"+:"]) && word.length > 1) {
         array = [self.emojis filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self BEGINSWITH[c] %@", word]];
     }
     
@@ -480,7 +480,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     if ([self.foundPrefix isEqualToString:@"#"]) {
         item = [NSString stringWithFormat:@"# %@", item];
     }
-    else if ([self.foundPrefix isEqualToString:@":"]) {
+    else if (([self.foundPrefix isEqualToString:@":"] || [self.foundPrefix isEqualToString:@"+:"])) {
         item = [NSString stringWithFormat:@":%@:", item];
     }
     
@@ -543,7 +543,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
         if ([self.foundPrefix isEqualToString:@"@"] && self.foundPrefixRange.location == 0) {
             [item appendString:@":"];
         }
-        else if ([self.foundPrefix isEqualToString:@":"]) {
+        else if (([self.foundPrefix isEqualToString:@":"] || [self.foundPrefix isEqualToString:@"+:"])) {
             [item appendString:@":"];
         }
         

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -1388,14 +1388,15 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
     [self slk_invalidateAutoCompletion];
     
     if (word.length > 0) {
-        NSString *prefix = [word substringWithRange:NSMakeRange(0, 1)];
         
-        if ([self.registeredPrefixes containsObject:prefix]) {
-            // Captures the detected symbol prefix
-            _foundPrefix = prefix;
-            
-            // Used later for replacing the detected range with a new string alias returned in -acceptAutoCompletionWithString:
-            _foundPrefixRange = NSMakeRange(range.location, prefix.length);
+        for (NSString *prefix in self.registeredPrefixes) {
+            if ([word hasPrefix:prefix]) {
+                // Captures the detected symbol prefix
+                _foundPrefix = prefix;
+                
+                // Used later for replacing the detected range with a new string alias returned in -acceptAutoCompletionWithString:
+                _foundPrefixRange = NSMakeRange(range.location, prefix.length);
+            }
         }
     }
     


### PR DESCRIPTION
Before, auto-completion prefixes would only be detected if they were 1 character long max.
Now, there are no limitations, so you can go wild by registering any sort of prefixes `@"+:"`, `@"blah"` and even emoji prefixes `@"😱"`!

![image](https://cloud.githubusercontent.com/assets/590579/8624870/f0dc58e6-26ef-11e5-89b0-041d373d97ca.png)
