### PR TITLE
Adds the ability to ignore the textInputbar adjustment.

### DIFF
--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -203,6 +203,13 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (BOOL)forceTextInputbarAdjustmentForResponder:(UIResponder *)responder;
 
 /**
+ Verifies if the text input bar should still move up/down when it is first responder. Default is NO.
+ This is very useful when presenting the view controller in a custom modal presentation, when there keyboard events are being handled externally to reframe the presented view.
+ You don't need call super since this method doesn't do anything.
+ */
+- (BOOL)ignoreTextInputbarAdjustment;
+
+/**
  Notifies the view controller that the keyboard changed status.
  You can override this method to perform additional tasks associated with presenting the view. You don't need call super since this method doesn't do anything.
  

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -404,6 +404,10 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
         return 0.0;
     }
     
+    if ([self ignoreTextInputbarAdjustment]) {
+        return 0.0;
+    }
+    
     CGRect endFrame = [self.view convertRect:[notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
     return MAX(0.0, CGRectGetHeight(self.view.bounds) - CGRectGetMinY(endFrame) - CGRectGetHeight(self.inputAccessoryView.bounds));
 }
@@ -603,6 +607,11 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return self.shouldForceTextInputbarAdjustment;
 #pragma GCC diagnostic pop
+}
+
+- (BOOL)ignoreTextInputbarAdjustment
+{
+    return NO;
 }
 
 - (void)didChangeKeyboardStatus:(SLKKeyboardStatus)status


### PR DESCRIPTION
This is very useful when presenting the view controller in a custom modal presentation, when there keyboard events are being handled externally to reframe the presented view.