### PR TITLE
Adds the ability to show/hide input bar. Closes #203. Closes #229

### DIFF
--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -122,7 +122,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     self.textInputbar.maxCharCount = 256;
     self.textInputbar.counterStyle = SLKCounterStyleSplit;
     self.textInputbar.counterPosition = SLKCounterPositionTop;
-
+    
 #if !DEBUG_CUSTOM_TYPING_INDICATOR
     self.typingIndicatorView.canResignByTouch = YES;
 #endif

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -446,7 +446,7 @@
         _charCountLabelVCs = [NSLayoutConstraint constraintsWithVisualFormat:@"V:[charCountLabel]-(bottom)-[rightButton]" options:0 metrics:metrics views:views];
     }
     else {
-        _charCountLabelVCs = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(<=top)-[charCountLabel]-(>=0)-|" options:0 metrics:metrics views:views];
+        _charCountLabelVCs = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(<=top,>=0)-[charCountLabel]-(>=0)-|" options:0 metrics:metrics views:views];
     }
     
     [self addConstraints:self.charCountLabelVCs];
@@ -619,7 +619,7 @@
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=rightVerMargin)-[rightButton]-(<=rightVerMargin)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left@250)-[charCountLabel(<=50@1000)]-(right@750)-|" options:0 metrics:metrics views:views]];
     
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[contentView(0)]-(<=top)-[textView(minTextViewHeight@250)]-(bottom)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[contentView(0)]-(<=top)-[textView(minTextViewHeight@250)]-(<=bottom)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:metrics views:views]];
     
     self.editorContentViewHC = [self slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.editorContentView secondItem:nil];

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -457,7 +457,7 @@
 
 - (BOOL)canEditText:(NSString *)text
 {
-    if (self.isEditing && [self.textView.text isEqualToString:text]) {
+    if ((self.isEditing && [self.textView.text isEqualToString:text]) || self.controller.isTextInputbarHidden) {
         return NO;
     }
     
@@ -466,7 +466,7 @@
 
 - (void)beginTextEditing
 {
-    if (self.isEditing) {
+    if (self.isEditing || self.controller.isTextInputbarHidden) {
         return;
     }
     
@@ -481,7 +481,7 @@
 
 - (void)endTextEdition
 {
-    if (!self.isEditing) {
+    if (!self.isEditing || self.controller.isTextInputbarHidden) {
         return;
     }
     

--- a/Source/Classes/SLKTextView.m
+++ b/Source/Classes/SLKTextView.m
@@ -125,8 +125,7 @@ NSString * const SLKTextViewPastedItemData =                        @"SLKTextVie
 
 - (UILabel *)placeholderLabel
 {
-    if (!_placeholderLabel)
-    {
+    if (!_placeholderLabel) {
         _placeholderLabel = [UILabel new];
         _placeholderLabel.clipsToBounds = NO;
         _placeholderLabel.autoresizesSubviews = NO;

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -294,6 +294,14 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)willRequestUndo;
 
 /**
+ Show/Hides the input bar
+ 
+ @param hide Bool to determine whether to hide or show
+ @param animated Bool to determine whether change should be animated or not
+ */
+- (void)hideInputBar:(BOOL)hide animated:(BOOL)animated;
+
+/**
  Notifies the view controller when the user has pressed the Return key (↵) with an external keyboard.
  You can override this method to perform additional tasks. You MUST call super at some point in your implementation.
  */

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -194,22 +194,6 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)dismissKeyboard:(BOOL)animated;
 
 /**
- Verifies if the text input bar should still move up/down even if it is not first responder. Default is NO.
- You can override this method to perform additional tasks associated with presenting the view. You don't need call super since this method doesn't do anything.
- 
- @param responder The current first responder object.
- @return YES so the text input bar still move up/down.
- */
-- (BOOL)forceTextInputbarAdjustmentForResponder:(UIResponder *)responder;
-
-/**
- Verifies if the text input bar should still move up/down when it is first responder. Default is NO.
- This is very useful when presenting the view controller in a custom modal presentation, when there keyboard events are being handled externally to reframe the presented view.
- You don't need call super since this method doesn't do anything.
- */
-- (BOOL)ignoreTextInputbarAdjustment;
-
-/**
  Notifies the view controller that the keyboard changed status.
  You can override this method to perform additional tasks associated with presenting the view. You don't need call super since this method doesn't do anything.
  
@@ -294,14 +278,6 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)willRequestUndo;
 
 /**
- Show/Hides the input bar
- 
- @param hide Bool to determine whether to hide or show
- @param animated Bool to determine whether change should be animated or not
- */
-- (void)hideInputBar:(BOOL)hide animated:(BOOL)animated;
-
-/**
  Notifies the view controller when the user has pressed the Return key (↵) with an external keyboard.
  You can override this method to perform additional tasks. You MUST call super at some point in your implementation.
  */
@@ -318,6 +294,40 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  You can override this method to perform additional tasks. You MUST call super at some point in your implementation.
  */
 - (void)didPressArrowKey:(id)sender NS_REQUIRES_SUPER;
+
+
+#pragma mark - Text Input Bar Adjustment
+///------------------------------------------------
+/// @name Text Input Bar Adjustment
+///------------------------------------------------
+
+/** YES if the text inputbar is visible. Default is YES. */
+@property (nonatomic, getter=isTextInputbarHidden) BOOL textInputbarHidden;
+
+/**
+ Changes the visibility of the text input bar.
+ Calling this method with the animated parameter set to NO is equivalent to setting the value of the toolbarHidden property directly.
+ 
+ @param hidden Specify YES to hide the toolbar or NO to show it.
+ @param animated Specify YES if you want the toolbar to be animated on or off the screen.
+ */
+- (void)setTextInputbarHidden:(BOOL)hidden animated:(BOOL)animated;
+
+/**
+ Verifies if the text input bar should still move up/down even if it is not first responder. Default is NO.
+ You can override this method to perform additional tasks associated with presenting the view. You don't need call super since this method doesn't do anything.
+ 
+ @param responder The current first responder object.
+ @return YES so the text input bar still move up/down.
+ */
+- (BOOL)forceTextInputbarAdjustmentForResponder:(UIResponder *)responder;
+
+/**
+ Verifies if the text input bar should still move up/down when it is first responder. Default is NO.
+ This is very useful when presenting the view controller in a custom modal presentation, when there keyboard events are being handled externally to reframe the presented view.
+ You don't need call super since this method doesn't do anything.
+ */
+- (BOOL)ignoreTextInputbarAdjustment;
 
 
 #pragma mark - Text Edition

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -822,9 +822,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)setTextInputbarHidden:(BOOL)hidden animated:(BOOL)animated
 {
-//    if (self.isTextInputbarHidden == hidden) {
-//        return;
-//    }
+    if (self.isTextInputbarHidden == hidden) {
+        return;
+    }
     
     __weak typeof(self) weakSelf = self;
     
@@ -846,9 +846,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     };
     
     if (animated) {
-        NSTimeInterval duration = animated ? 0.25 : 0.0;
-
-        [UIView animateWithDuration:duration animations:animations completion:completion];
+        [UIView animateWithDuration:0.25 animations:animations completion:completion];
     }
     else {
         animations();

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -811,6 +811,18 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     [alert show];
 }
 
+- (void)hideInputBar:(BOOL)hide animated:(BOOL)animated
+{
+    __weak typeof(self) weakSelf = self;
+    
+    [UIView animateWithDuration:animated ? 0.2 : 0.0 animations:^{
+        weakSelf.textInputbar.alpha = hide ? 0 : 1;
+        weakSelf.textInputbarHC.constant = hide ? 0 : weakSelf.textInputbar.appropriateHeight;
+        [weakSelf.textInputbar setNeedsLayout];
+        [weakSelf.textInputbar layoutIfNeeded];
+    }];
+}
+
 
 #pragma mark - Private Methods
 
@@ -1864,7 +1876,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                             @"textInputbar": self.textInputbar,
                             };
     
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[scrollView(0@750)][autoCompletionView(0@750)][typingIndicatorView(0)]-0@999-[textInputbar(>=0)]-0-|" options:0 metrics:nil views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[scrollView(0@750)][autoCompletionView(0@750)][typingIndicatorView(0)]-0@999-[textInputbar(==0)]-0-|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[scrollView]|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[autoCompletionView]|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[typingIndicatorView]|" options:0 metrics:nil views:views]];
@@ -2039,7 +2051,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     _verticalPanGesture.delegate = nil;
     _verticalPanGesture = nil;
     _scrollViewHC = nil;
-    _textInputbarHC = nil;
     _textInputbarHC = nil;
     _typingIndicatorViewHC = nil;
     _autoCompletionViewHC = nil;

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -820,20 +820,18 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         return;
     }
     
+    _textInputbarHidden = hidden;
+
     __weak typeof(self) weakSelf = self;
     
     void (^animations)() = ^void(){
         
         weakSelf.textInputbarHC.constant = hidden ? 0 : weakSelf.textInputbar.appropriateHeight;
         
-        [weakSelf.view setNeedsLayout];
         [weakSelf.view layoutIfNeeded];
     };
     
     void (^completion)(BOOL finished) = ^void(BOOL finished){
-        
-        _textInputbarHidden = hidden;
-        
         if (hidden) {
             [self dismissKeyboard:YES];
         }

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -709,7 +709,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     [self.textInputbar beginTextEditing];
     
-    // Setting the text after calling -beginTextEditing is safer when in landscape orientation
+    // Setting the text after calling -beginTextEditing is safer when on landscape orientation
     if (SLK_IS_LANDSCAPE) {
         [self.textView setText:text];
     }

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -253,8 +253,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (UITableView *)tableViewWithStyle:(UITableViewStyle)style
 {
-    if (!_tableView)
-    {
+    if (!_tableView) {
         _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:style];
         _tableView.translatesAutoresizingMaskIntoConstraints = NO;
         _tableView.scrollsToTop = YES;
@@ -267,8 +266,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (UICollectionView *)collectionViewWithLayout:(UICollectionViewLayout *)layout
 {
-    if (!_collectionView)
-    {
+    if (!_collectionView) {
         _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
         _collectionView.translatesAutoresizingMaskIntoConstraints = NO;
         _collectionView.scrollsToTop = YES;
@@ -280,8 +278,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (UITableView *)autoCompletionView
 {
-    if (!_autoCompletionView)
-    {
+    if (!_autoCompletionView) {
         _autoCompletionView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
         _autoCompletionView.translatesAutoresizingMaskIntoConstraints = NO;
         _autoCompletionView.backgroundColor = [UIColor colorWithWhite:0.97 alpha:1.0];
@@ -302,8 +299,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (SLKTextInputbar *)textInputbar
 {
-    if (!_textInputbar)
-    {
+    if (!_textInputbar) {
         _textInputbar = [[SLKTextInputbar alloc] initWithTextViewClass:self.textViewClass];
         _textInputbar.translatesAutoresizingMaskIntoConstraints = NO;
         _textInputbar.controller = self;
@@ -325,8 +321,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (UIView <SLKTypingIndicatorProtocol> *)typingIndicatorProxyView
 {
-    if (!_typingIndicatorProxyView)
-    {
+    if (!_typingIndicatorProxyView) {
         Class class = self.typingIndicatorViewClass ? : [SLKTypingIndicatorView class];
         
         _typingIndicatorProxyView = [[class alloc] init];
@@ -583,8 +578,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         return;
     }
     
-    if (!animated)
-    {
+    if (!animated) {
         [UIView performWithoutAnimation:^{
             [self.textView resignFirstResponder];
         }];

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -818,8 +818,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     [UIView animateWithDuration:animated ? 0.2 : 0.0 animations:^{
         weakSelf.textInputbar.alpha = hide ? 0 : 1;
         weakSelf.textInputbarHC.constant = hide ? 0 : weakSelf.textInputbar.appropriateHeight;
-        [weakSelf.textInputbar setNeedsLayout];
-        [weakSelf.textInputbar layoutIfNeeded];
+        [weakSelf.view setNeedsLayout];
+        [weakSelf.view layoutIfNeeded];
     }];
 }
 

--- a/Source/Classes/SLKTypingIndicatorView.m
+++ b/Source/Classes/SLKTypingIndicatorView.m
@@ -109,8 +109,7 @@
 
 - (UILabel *)textLabel
 {
-    if (!_textLabel)
-    {
+    if (!_textLabel) {
         _textLabel = [UILabel new];
         _textLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _textLabel.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
@aryaxt: I've made some improvements and refactorings to your original PR in #229:
- Renamed `hideInputBar:animated:` to `setTextInputbarHidden:animated:`
- Dismissed the keyboard and the auto-completion view right after hiding the textInputBar
- Fixed cases where hiding the textInputBar wouldn't be possible when the keyboard was up
- Avoided hiding the textInputBar with alpha, instead fixed some auto-layout constraints so the textView would follow the dismissal animation

Known bugs:
- when rotating the device, the scrollView's wouldn't extend to the bottom of the screen when the textInputBar is hidden.

Please try pulling this branch. Thanks for this great improvement!