### PR TITLE
Fixes wrong auto-completion view height when switching tokens while auto-completion is active

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -26,6 +26,8 @@ NSString * const SLKKeyboardDidHideNotification =   @"SLKKeyboardDidHideNotifica
 
 NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKTextViewController' string
 
+CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
+
 @interface SLKTextViewController ()
 {
     CGPoint _scrollViewOffsetBeforeDragging;
@@ -795,12 +797,14 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
 
 - (CGFloat)maximumHeightForAutoCompletionView
 {
-    CGFloat maxiumumHeight = 140.0;
-    CGFloat scrollViewHeight = self.scrollViewHC.constant;
-    scrollViewHeight -= [self slk_topBarsHeight];
+    CGFloat maxiumumHeight = SLKAutoCompletionViewDefaultHeight;
     
-    if (scrollViewHeight < maxiumumHeight) {
-        maxiumumHeight = scrollViewHeight;
+    if (!self.isAutoCompleting) {
+        CGFloat scrollViewHeight = self.scrollViewHC.constant - [self slk_topBarsHeight];
+        
+        if (scrollViewHeight < maxiumumHeight) {
+            maxiumumHeight = scrollViewHeight;
+        }
     }
     
     return maxiumumHeight;
@@ -1590,11 +1594,11 @@ NSInteger const SLKAlertViewClearTextTag = 1534347677; // absolute hash of 'SLKT
         viewHeight = maximumHeight;
     }
     
-    CGFloat tableHeight = self.scrollViewHC.constant + self.autoCompletionViewHC.constant;
+    CGFloat contentViewHeight = self.scrollViewHC.constant + self.autoCompletionViewHC.constant;
     
-    // On iPhone, the auto-completion view can't extend beyond the table view height
-    if (SLK_IS_IPHONE && viewHeight > tableHeight) {
-        viewHeight = tableHeight;
+    // On iPhone, the auto-completion view can't extend beyond the content view height
+    if (SLK_IS_IPHONE && viewHeight > contentViewHeight) {
+        viewHeight = contentViewHeight;
     }
     
     self.autoCompletionViewHC.constant = viewHeight;


### PR DESCRIPTION
Fixes this sort of behavior, when the auto-completion view is partially visible because of a bad height calculation:
![image](https://cloud.githubusercontent.com/assets/590579/9243265/c2891454-4164-11e5-9a0c-5b20eef84d6a.png)