### PR TITLE
Improved Interactive keyboard panning

### DIFF
--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -218,7 +218,7 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
 
 - (BOOL)ignoreTextInputbarAdjustment
 {
-    return NO;
+    return [super ignoreTextInputbarAdjustment];
 }
 
 - (void)didChangeKeyboardStatus:(SLKKeyboardStatus)status

--- a/Source/Additions/UIScrollView+SLKAdditions.m
+++ b/Source/Additions/UIScrollView+SLKAdditions.m
@@ -30,12 +30,12 @@
 
 - (BOOL)slk_isAtTop
 {
-    return CGRectGetMinY([self slk_visibleRect]) == CGRectGetMinY([self slk_topRect]);
+    return CGRectGetMinY([self slk_visibleRect]) < CGRectGetMinY([self slk_topRect]);
 }
 
 - (BOOL)slk_isAtBottom
 {
-    return CGRectGetMaxY([self slk_visibleRect]) == CGRectGetMaxY([self slk_bottomRect]);
+    return CGRectGetMaxY([self slk_visibleRect]) > CGRectGetMaxY([self slk_bottomRect]);
 }
 
 - (CGRect)slk_visibleRect
@@ -48,12 +48,12 @@
 
 - (CGRect)slk_topRect
 {
-    return CGRectMake(0, 0, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds));
+    return CGRectMake(0, 0, CGRectGetWidth([self slk_visibleRect]), CGRectGetHeight([self slk_visibleRect]));
 }
 
 - (CGRect)slk_bottomRect
 {
-    return CGRectMake(0, self.contentSize.height - CGRectGetHeight(self.bounds), CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds));
+    return CGRectMake(0, self.contentSize.height - CGRectGetHeight([self slk_visibleRect]), CGRectGetWidth([self slk_visibleRect]), CGRectGetHeight([self slk_visibleRect]));
 }
 
 - (void)slk_stopScrolling

--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -159,7 +159,7 @@
 {
     if (!_inputAccessoryView)
     {
-        _inputAccessoryView = [[SLKInputAccessoryView alloc] initWithFrame:self.bounds];
+        _inputAccessoryView = [[SLKInputAccessoryView alloc] initWithFrame:CGRectZero];
         _inputAccessoryView.backgroundColor = [UIColor clearColor];
         _inputAccessoryView.userInteractionEnabled = NO;
     }
@@ -371,7 +371,6 @@
 - (void)setBackgroundColor:(UIColor *)color
 {
     self.barTintColor = color;
-    self.textView.inputAccessoryView.backgroundColor = color;
     self.editorContentView.backgroundColor = color;
 }
 

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -85,7 +85,10 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 @property (nonatomic, assign, getter = isKeyboardPanningEnabled) BOOL keyboardPanningEnabled;
 
 /** YES if an external keyboard has been detected (this value updates only when the text view becomes first responder). */
-@property (nonatomic, readonly) BOOL isExternalKeyboardDetected;
+@property (nonatomic, readonly, getter=isExternalKeyboardDetected) BOOL externalKeyboardDetected;
+
+/**  */
+@property (nonatomic, readonly, getter=isKeyboardUndocked) BOOL keyboardUndocked;
 
 /** YES if after right button press, the text view is cleared out. Default is YES. */
 @property (nonatomic, assign) BOOL shouldClearTextAtRightButtonPress;

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -503,6 +503,8 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 
 /** UIScrollViewDelegate */
 - (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView NS_REQUIRES_SUPER;
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate NS_REQUIRES_SUPER;
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView NS_REQUIRES_SUPER;
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView NS_REQUIRES_SUPER;
 
 /** UIGestureRecognizerDelegate */

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -197,6 +197,22 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)dismissKeyboard:(BOOL)animated;
 
 /**
+ Verifies if the text input bar should still move up/down even if it is not first responder. Default is NO.
+ You can override this method to perform additional tasks associated with presenting the view. You don't need call super since this method doesn't do anything.
+ 
+ @param responder The current first responder object.
+ @return YES so the text input bar still move up/down.
+ */
+- (BOOL)forceTextInputbarAdjustmentForResponder:(UIResponder *)responder;
+
+/**
+ Verifies if the text input bar should still move up/down when it is first responder. Default is NO.
+ This is very useful when presenting the view controller in a custom modal presentation, when there keyboard events are being handled externally to reframe the presented view.
+ You SHOULD call super to inherit some conditionals.
+ */
+- (BOOL)ignoreTextInputbarAdjustment NS_REQUIRES_SUPER;
+
+/**
  Notifies the view controller that the keyboard changed status.
  You can override this method to perform additional tasks associated with presenting the view. You don't need call super since this method doesn't do anything.
  

--- a/Source/Classes/SLKTextViewController.h
+++ b/Source/Classes/SLKTextViewController.h
@@ -69,10 +69,10 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  */
 @property (nonatomic, readonly) UIView <SLKTypingIndicatorProtocol> *typingIndicatorProxyView;
 
-/** A single tap gesture used to dismiss the keyboard. */
+/** A single tap gesture used to dismiss the keyboard. SLKTextViewController is its delegate. */
 @property (nonatomic, readonly) UIGestureRecognizer *singleTapGesture;
 
-/** A vertical pan gesture used for bringing the keyboard from the bottom. */
+/** A vertical pan gesture used for bringing the keyboard from the bottom. SLKTextViewController is its delegate. */
 @property (nonatomic, readonly) UIPanGestureRecognizer *verticalPanGesture;
 
 /** YES if control's animation should have bouncy effects. Default is YES. */

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -18,6 +18,9 @@
 #import "SLKUIConstants.h"
 #import "UIResponder+SLKAdditions.h"
 
+/** Feature flagged while waiting to implement a more reliable technique. */
+#define SLKBottomPanningEnabled NO
+
 NSString * const SLKKeyboardWillShowNotification =  @"SLKKeyboardWillShowNotification";
 NSString * const SLKKeyboardDidShowNotification =   @"SLKKeyboardDidShowNotification";
 NSString * const SLKKeyboardWillHideNotification =  @"SLKKeyboardWillHideNotification";
@@ -886,7 +889,12 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             }
         }
         
+#if SLKBottomPanningEnabled
         presenting = YES;
+#else
+        [self presentKeyboard:YES];
+        return;
+#endif
     }
 
     switch (gesture.state) {
@@ -896,7 +904,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             dragging = NO;
             
             if (presenting) {
-                // Let's first present the keyboard
+                // Let's first present the keyboard without animation
                 [self presentKeyboard:NO];
                 
                 // So we can capture the keyboard's view
@@ -905,8 +913,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                 originalFrame = keyboardView.frame;
                 originalFrame.origin.y = CGRectGetMaxY(self.view.frame);
                 
-                // And manipulate its frame (illegaly)
-                // TODO: Fix an occasional layout glitch when the keyboard appears for the first time
+                // And move the keyboard to the bottom edge
+                // TODO: Fix an occasional layout glitch when the keyboard appears for the first time.
                 keyboardView.frame = originalFrame;
             }
             

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -385,9 +385,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     CGFloat viewHeight = CGRectGetHeight(self.view.bounds);
     CGFloat keyboardMinY = CGRectGetMinY(keyboardRect);
-    CGFloat inputAccessoryViewHeight = CGRectGetHeight(self.textInputbar.inputAccessoryView.bounds);
     
-    return MAX(0.0, viewHeight - (keyboardMinY + inputAccessoryViewHeight));
+    return MAX(0.0, viewHeight - keyboardMinY);
 }
 
 - (CGFloat)slk_appropriateScrollViewHeight
@@ -1066,7 +1065,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         endFrame = SLKRectInvert(endFrame);
     }
     
-    CGFloat keyboardHeight = CGRectGetHeight(endFrame)-CGRectGetHeight(self.textInputbar.inputAccessoryView.bounds);
+    CGFloat keyboardHeight = CGRectGetHeight(endFrame);
     
     beginFrame.size.height = keyboardHeight;
     endFrame.size.height = keyboardHeight;
@@ -1158,7 +1157,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     // Based on http://stackoverflow.com/a/5760910/287403
     // We can determine if the external keyboard is showing by adding the origin.y of the target finish rect (end when showing, begin when hiding) to the inputAccessoryHeight.
     // If it's greater(or equal) the window height, it's an external keyboard.
-    CGFloat inputAccessoryHeight = self.textInputbar.inputAccessoryView.frame.size.height;
     CGRect beginRect = [notification.userInfo[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
     CGRect endRect = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
     
@@ -1177,15 +1175,15 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     CGRect convertEnd = [baseView convertRect:endRect fromView:nil];
     
     if ([notification.name isEqualToString:UIKeyboardWillShowNotification]) {
-        if (convertEnd.origin.y + inputAccessoryHeight >= viewBounds.size.height) {
+        if (convertEnd.origin.y >= viewBounds.size.height) {
             _externalKeyboardDetected = YES;
         }
     }
     else if ([notification.name isEqualToString:UIKeyboardWillHideNotification]) {
         // The additional logic check here (== to width) accounts for a glitch (iOS 8 only?) where the window has rotated it's coordinates
         // but the beginRect doesn't yet reflect that. It should never cause a false positive.
-        if (convertBegin.origin.y + inputAccessoryHeight >= viewBounds.size.height ||
-            convertBegin.origin.y + inputAccessoryHeight == viewBounds.size.width) {
+        if (convertBegin.origin.y >= viewBounds.size.height ||
+            convertBegin.origin.y == viewBounds.size.width) {
             _externalKeyboardDetected = YES;
         }
     }

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -898,7 +898,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             
             if (presenting) {
                 // Let's first present the keyboard
-                [self.textView becomeFirstResponder];
+                [self presentKeyboard:NO];
                 
                 // So we can capture the keyboard's view
                 keyboardView = [self.textInputbar.inputAccessoryView keyboardViewProxy];

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -308,10 +308,10 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         
         _textInputbar.textView.delegate = self;
         
-        _verticalPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(slk_didPanTextView:)];
+        _verticalPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(slk_didPanScrollView:)];
         _verticalPanGesture.delegate = self;
         
-        [_textInputbar.textView addGestureRecognizer:self.verticalPanGesture];
+        [_textInputbar addGestureRecognizer:self.verticalPanGesture];
     }
     return _textInputbar;
 }
@@ -1870,17 +1870,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         return [self.textView isFirstResponder] && !self.isExternalKeyboardDetected;
     }
     else if ([gesture isEqual:self.verticalPanGesture]) {
-        
-        if ([self.textView isFirstResponder]) {
-            return NO;
-        }
-        
-        CGPoint velocity = [self.verticalPanGesture velocityInView:self.view];
-        
-        // Vertical panning, from bottom to top only
-        if (velocity.y < 0 && ABS(velocity.y) > ABS(velocity.x) && ![self.textInputbar.textView isFirstResponder]) {
-            return YES;
-        }
+        return [self.textView isFirstResponder] && !self.isExternalKeyboardDetected;
     }
     
     return NO;

--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -308,7 +308,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         
         _textInputbar.textView.delegate = self;
         
-        _verticalPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(slk_didPanScrollView:)];
+        _verticalPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(slk_didPanTextInputBar:)];
         _verticalPanGesture.delegate = self;
         
         [_textInputbar addGestureRecognizer:self.verticalPanGesture];
@@ -494,7 +494,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     [scrollView addGestureRecognizer:self.singleTapGesture];
     
-    [scrollView.panGestureRecognizer addTarget:self action:@selector(slk_didPanScrollView:)];
+    [scrollView.panGestureRecognizer addTarget:self action:@selector(slk_didPanTextInputBar:)];
     
     _scrollViewProxy = scrollView;
 }
@@ -843,7 +843,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 #pragma mark - Private Methods
 
-- (void)slk_didPanScrollView:(UIPanGestureRecognizer *)gesture
+- (void)slk_didPanTextInputBar:(UIPanGestureRecognizer *)gesture
 {
     // Skips if the panning is not enabled
     if (!self.keyboardPanningEnabled) {


### PR DESCRIPTION
This new feature basically allows to bring the keyboard up, progressively, from the bottom, by either dragging the text input bar (UIToolbar) or the scrollView if it's at the very bottom of the content size. Also, dismissing the keyboard interactively can start from the `textInputbar` too (before we were only using the scrollView's native panning gesture recognizer).

Also fixes a few textInput adjustment on iPad when the keyboard was docked/split, detecting and exposing it with a new flag `isKeyboardDocked`.

![interative_keyboard_panning](https://cloud.githubusercontent.com/assets/590579/9448678/5423f254-4a74-11e5-870d-80c377d24937.gif)

Known issues:
- When dragging from the bottom, the keyboard flashes occasionally when presented for the first time. It glitches more frequently on iPad.
- When dragging from the bottom and releasing with speed to open the keyboard, the speed is `0` so the keyboard is dismissed instead of being presented.
- Sometimes, the keyboard disappears leaving a white area while the text input is still up.

Closes #247