### PR TITLE
Fix KVO removal issue when buttons are overridden

### DIFF
--- a/Source/Classes/SLKTextInputbar.m
+++ b/Source/Classes/SLKTextInputbar.m
@@ -719,11 +719,11 @@
 {
     [self slk_unregisterNotifications];
     
-    [_leftButton.imageView removeObserver:self forKeyPath:NSStringFromSelector(@selector(image))];
-    [_rightButton.titleLabel removeObserver:self forKeyPath:NSStringFromSelector(@selector(font))];
+    [self.leftButton.imageView removeObserver:self forKeyPath:NSStringFromSelector(@selector(image))];
+    [self.rightButton.titleLabel removeObserver:self forKeyPath:NSStringFromSelector(@selector(font))];
     
-    _leftButton = nil;
-    _rightButton = nil;
+    self.leftButton = nil;
+    self.rightButton = nil;
     
     _inputAccessoryView = nil;
     _textView.delegate = nil;


### PR DESCRIPTION
If we don't use the getters to access left and right buttons, the KVO is removed from the wrong instance variables if a subclass decides to override the leftButton/rightButton getters.

You can reproduce this issue on XCode 7.1/iOS 9.1 by creating a subclass of SLKTextInputbar, overriding the self.rightButton getter and then triggering a dealloc.  Debug builds will crash with the warning that an observer is not being removed.