### PR TITLE
Fix issue with layout animation when pushing VC with visible keyboard

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -1328,14 +1328,24 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         [self slk_postKeyboarStatusNotification:notification];
     }
     
-    // Only for this animation, we set bo to bounce since we want to give the impression that the text input is glued to the keyboard.
-    [self.view slk_animateLayoutIfNeededWithDuration:duration
-                                              bounce:NO
-                                             options:(curve<<16)|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
-                                          animations:^{
-                                              [self slk_scrollToBottomIfNeeded];
-                                          }
-                                          completion:NULL];
+    CGRect beginFrame = [notification.userInfo[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
+    CGRect endFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    // Begin and end frames are the same when the keyboard is shown during navigation controller's push animation.
+    // The animation happens in window coordinates (slides from right to left) but doesn't in the view controller's view coordinates.
+    BOOL frameWillChange = !CGRectEqualToRect(beginFrame, endFrame);
+    
+    if (frameWillChange) {
+        // Only for this animation, we set bo to bounce since we want to give the impression that the text input is glued to the keyboard.
+        [self.view slk_animateLayoutIfNeededWithDuration:duration
+                                                  bounce:NO
+                                                 options:(curve<<16)|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
+                                              animations:^{
+                                                  [self slk_scrollToBottomIfNeeded];
+                                              }
+                                              completion:NULL];
+    } else {
+        [self slk_scrollToTopIfNeeded];
+    }
 }
 
 - (void)slk_didShowOrHideKeyboard:(NSNotification *)notification


### PR DESCRIPTION
Hi! I've noticed an issue with animation when I tried to push a view controller with an already visible keyboard.

Here's a video of how it looked before my changes:
https://dl.dropboxusercontent.com/u/5184129/movies/slack_before.mov
and after:
https://dl.dropboxusercontent.com/u/5184129/movies/slack_after.mov

These videos are based on `Messenger-Storyboard` scheme with one small change. I added:

```obj-c
- (BOOL)becomeFirstResponder
{
  return [self.textView becomeFirstResponder];
}
```
to `MessageViewController.m`.

