### PR TITLE
Carthage compatibility

### DIFF
--- a/SlackTextViewController/SlackTextViewController.xcodeproj/xcshareddata/xcschemes/SlackTextViewController.xcscheme
+++ b/SlackTextViewController/SlackTextViewController.xcodeproj/xcshareddata/xcschemes/SlackTextViewController.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5A782731BD0CEF300EC230B"
+               BuildableName = "SlackTextViewController.framework"
+               BlueprintName = "SlackTextViewController"
+               ReferencedContainer = "container:SlackTextViewController.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5A7827D1BD0CEF400EC230B"
+               BuildableName = "SlackTextViewControllerTests.xctest"
+               BlueprintName = "SlackTextViewControllerTests"
+               ReferencedContainer = "container:SlackTextViewController.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F5A782731BD0CEF300EC230B"
+            BuildableName = "SlackTextViewController.framework"
+            BlueprintName = "SlackTextViewController"
+            ReferencedContainer = "container:SlackTextViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F5A782731BD0CEF300EC230B"
+            BuildableName = "SlackTextViewController.framework"
+            BlueprintName = "SlackTextViewController"
+            ReferencedContainer = "container:SlackTextViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F5A782731BD0CEF300EC230B"
+            BuildableName = "SlackTextViewController.framework"
+            BlueprintName = "SlackTextViewController"
+            ReferencedContainer = "container:SlackTextViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Tried to include SlackTextViewController in my project through Carthage, was told
```
*** Skipped building SlackTextViewController due to the error:
Dependency "SlackTextViewController" has no shared framework schemes

If you believe this to be an error, please file an issue with the maintainers at https://github.com/slackhq/SlackTextViewController/issues/new
```

Seems to be that you aren't sharing the framework scheme, I added that. If this is merged and a new tagged release is created (current latest is `v1.7.1`) I believe Carthage will be able to build SlackTextViewController