### PR TITLE
Fix rightButton margin is not correctly set when autoHideRightButton …

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -399,7 +399,8 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     _autoHideRightButton = hide;
     
     self.rightButtonWC.constant = [self slk_appropriateRightButtonWidth];
-    
+    self.rightMarginWC.constant = [self slk_appropriateRightButtonMargin];
+
     [self layoutIfNeeded];
 }
 


### PR DESCRIPTION
…= NO

https://github.com/slackhq/SlackTextViewController/commit/dceedc70393e873d70c82da39c9f2cc9f18fda5a#diff-592522ed60e49c6ca08c23b1fa1ac14aR104 broke the behavior.

`autoHideRightButton` would affect the result of `slk_appropriateRightButtonMargin`, so we should update `rightMarginWC.constant` in the setter as with `rightButtonWC.constant`.