### PR TITLE
Fix case of nil that key for persistence

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1769,6 +1769,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (NSString *)slk_keyForPersistency
 {
     NSString *key = [self keyForTextCaching];
+    if (key == nil) {
+        return nil;
+    }
     return [NSString stringWithFormat:@"%@.%@", SLKTextViewControllerDomain, key];
 }
 

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1778,6 +1778,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (void)slk_reloadTextView
 {
     NSString *key = [self slk_keyForPersistency];
+    if (key == nil) {
+        return;
+    }
     NSString *cachedText = [[NSUserDefaults standardUserDefaults] objectForKey:key];
     
     if (self.textView.text.length == 0 || cachedText.length > 0) {


### PR DESCRIPTION
# What

if not override `keyForTextCaching` method, key for persistence is wrong key name like `com.slack.TextViewController.(null)`.
All channel uses same its key and load same saved a text.