### PR TITLE
Support Subclasses of UITableView or UICollectionView

### DIFF
--- a/SlackTextViewController/SlackTextViewController.xcodeproj/project.pbxproj
+++ b/SlackTextViewController/SlackTextViewController.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 				F5A782751BD0CEF300EC230B /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		F5A782751BD0CEF300EC230B /* Products */ = {
 			isa = PBXGroup;

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -156,6 +156,16 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (instancetype)initWithCoder:(NSCoder *)decoder SLK_DESIGNATED_INITIALIZER;
 
 /**
+ Returns a newly-created table view to be used when initializing instances
+ with `initWithTableViewStyle:`. Default creates a `UITableView` with the given style.
+ 
+ You can override this to initialize subclasses of `UITableView`.
+
+ @return A newly-allocated `UITableView`.
+ */
++ (UITableView *)createTableViewWithStyle:(UITableViewStyle)tableViewStyle;
+
+/**
  Returns the tableView style to be configured when using Interface Builder. Default is UITableViewStylePlain.
  You must override this method if you want to configure a tableView.
  
@@ -163,6 +173,16 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  @return The tableView style to be used in the new instantiated tableView.
  */
 + (UITableViewStyle)tableViewStyleForCoder:(NSCoder *)decoder;
+
+/**
+ Returns a newly-created collection view to be used when initializing instances
+ with `initWithCollectionViewLayout:`. Default creates a `UICollectionView` with the given layout.
+
+ You can override this to initialize subclasses of `UICollectionView`.
+
+ @return A newly-allocated `UICollectionView`.
+ */
++ (UICollectionView *)createCollectionViewWithLayout:(UICollectionViewLayout *)collectionViewLayout;
 
 /**
  Returns the tableView style to be configured when using Interface Builder. Default is nil.

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -247,9 +247,19 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 #pragma mark - Getters
 
++ (UITableView *)createTableViewWithStyle:(UITableViewStyle)tableViewStyle
+{
+    return [[UITableView alloc] initWithFrame:CGRectZero style:tableViewStyle];
+}
+
 + (UITableViewStyle)tableViewStyleForCoder:(NSCoder *)decoder
 {
     return UITableViewStylePlain;
+}
+
++ (UICollectionView *)createCollectionViewWithLayout:(UICollectionViewLayout *)collectionViewLayout
+{
+    return [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:collectionViewLayout];
 }
 
 + (UICollectionViewLayout *)collectionViewLayoutForCoder:(NSCoder *)decoder
@@ -260,7 +270,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (UITableView *)tableViewWithStyle:(UITableViewStyle)style
 {
     if (!_tableView) {
-        _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:style];
+        _tableView = [self.class createTableViewWithStyle:style];
         _tableView.translatesAutoresizingMaskIntoConstraints = NO;
         _tableView.scrollsToTop = YES;
         _tableView.dataSource = self;
@@ -273,7 +283,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (UICollectionView *)collectionViewWithLayout:(UICollectionViewLayout *)layout
 {
     if (!_collectionView) {
-        _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+        _collectionView = [self.class createCollectionViewWithLayout:layout];
         _collectionView.translatesAutoresizingMaskIntoConstraints = NO;
         _collectionView.scrollsToTop = YES;
         _collectionView.dataSource = self;


### PR DESCRIPTION
Awesome framework (and awesome product!) I'm hoping to use this in conjunction with the incomparable [AsyncDisplayKit](http://asyncdisplaykit.org) so I've added support for overriding the table view / collection view instance creation.

Unfortunately it wouldn't be enough to let them provide us a class, because `ASTableView` uses a different designated initializer `-initWithFrame:style:asyncDataFetching:`.