### PR TITLE
Bug with KVO in SLKTextInputBar

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -685,7 +685,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 - (void)slk_registerTo:(id)object forSelector:(SEL)selector
 {
     if (object) {
-        [object addObserver:self forKeyPath:NSStringFromSelector(selector) options:NSKeyValueObservingOptionNew context:NULL];
+        [object addObserver:self forKeyPath:NSStringFromSelector(selector) options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL];
     }
 }
 


### PR DESCRIPTION
You're comparing the old and new value here in the KVO callback https://github.com/slackhq/SlackTextViewController/blob/master/Source/SLKTextInputbar.m#L710 

but when you register for KVO, you're including just NSKeyValueObservingOptionNew, so the old change is nil, and the block inside the if fires everytime.

This PR fixes that