### PR TITLE
Private API Deprecation

### DIFF
--- a/Examples/Messenger-Shared/MessageTableViewCell.h
+++ b/Examples/Messenger-Shared/MessageTableViewCell.h
@@ -11,6 +11,9 @@
 static CGFloat kMessageTableViewCellMinimumHeight = 50.0;
 static CGFloat kMessageTableViewCellAvatarHeight = 30.0;
 
+static NSString *MessengerCellIdentifier = @"MessengerCell";
+static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
+
 @interface MessageTableViewCell : UITableViewCell
 
 @property (nonatomic, strong) UILabel *titleLabel;

--- a/Examples/Messenger-Shared/MessageTableViewCell.m
+++ b/Examples/Messenger-Shared/MessageTableViewCell.m
@@ -37,14 +37,19 @@
     NSDictionary *metrics = @{@"tumbSize": @(kMessageTableViewCellAvatarHeight),
                               @"padding": @15,
                               @"right": @10,
-                              @"left": @5,
-                              @"attchSize": @80,
+                              @"left": @5
                               };
     
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-left-[thumbnailView(tumbSize)]-right-[titleLabel(>=0)]-right-|" options:0 metrics:metrics views:views]];
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-left-[thumbnailView(tumbSize)]-right-[bodyLabel(>=0)]-right-|" options:0 metrics:metrics views:views]];
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-right-[titleLabel(20)]-left-[bodyLabel(>=0@999)]-left-|" options:0 metrics:metrics views:views]];
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-right-[thumbnailView(tumbSize)]-(>=0)-|" options:0 metrics:metrics views:views]];
+    
+    if ([self.reuseIdentifier isEqualToString:MessengerCellIdentifier]) {
+        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-right-[titleLabel(20)]-left-[bodyLabel(>=0@999)]-left-|" options:0 metrics:metrics views:views]];
+    }
+    else {
+        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[titleLabel]|" options:0 metrics:metrics views:views]];
+    }
 }
 
 - (void)prepareForReuse

--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -16,9 +16,6 @@
 
 #define DEBUG_CUSTOM_TYPING_INDICATOR 0
 
-static NSString *MessengerCellIdentifier = @"MessengerCell";
-static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
-
 @interface MessageViewController ()
 
 @property (nonatomic, strong) NSMutableArray *messages;
@@ -570,17 +567,16 @@ static NSString *AutoCompletionCellIdentifier = @"AutoCompletionCell";
     MessageTableViewCell *cell = (MessageTableViewCell *)[self.autoCompletionView dequeueReusableCellWithIdentifier:AutoCompletionCellIdentifier];
     cell.indexPath = indexPath;
     
-    NSString *item = self.searchResult[indexPath.row];
+    NSString *text = self.searchResult[indexPath.row];
     
     if ([self.foundPrefix isEqualToString:@"#"]) {
-        item = [NSString stringWithFormat:@"# %@", item];
+        text = [NSString stringWithFormat:@"# %@", text];
     }
     else if (([self.foundPrefix isEqualToString:@":"] || [self.foundPrefix isEqualToString:@"+:"])) {
-        item = [NSString stringWithFormat:@":%@:", item];
+        text = [NSString stringWithFormat:@":%@:", text];
     }
     
-    cell.titleLabel.text = item;
-    cell.titleLabel.font = [UIFont systemFontOfSize:14.0];
+    cell.titleLabel.text = text;
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     
     return cell;

--- a/Examples/Messenger.xcodeproj/project.pbxproj
+++ b/Examples/Messenger.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 				ORGANIZATIONNAME = "Slack Technologies, Inc.";
 				TargetAttributes = {
 					4F3EDB48199ED00F004C15D6 = {
-						DevelopmentTeam = BQR82RBBHL;
+						DevelopmentTeam = S6MX3RA9ZM;
 					};
 					4F86BF6419F011D0007A3D4A = {
 						CreatedOnToolsVersion = 6.0.1;

--- a/Source/SLKInputAccessoryView.m
+++ b/Source/SLKInputAccessoryView.m
@@ -27,7 +27,8 @@
     if (newSuperview) {
         if (SLK_IS_IOS9_AND_HIGHER) {
             
-            // NOTE: Because the keyboard is on its own view hierarchy since iOS 9,
+            // NOTE:
+            // Because the keyboard is on its own view hierarchy since iOS 9,
             // we needed to lookup for its view so we can move the text input whenever its origin changed.
             // We are disabling the detection of the keyboard on iOS 9 until a public API is available.
             //

--- a/Source/SLKInputAccessoryView.m
+++ b/Source/SLKInputAccessoryView.m
@@ -27,6 +27,13 @@
     if (newSuperview) {
         if (SLK_IS_IOS9_AND_HIGHER) {
             
+            // NOTE: Because the keyboard is on its own view hiearchy since iOS 9,
+            // we needed to lookup for its view so we can move the text input whenever its origin changed.
+            // We are disabling the detection of the keyboard on iOS 9 until a public API is available.
+            //
+            // Open Radar: http://openradar.appspot.com/radar?id=5021485877952512
+            
+            /*
             NSPredicate *windowPredicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@", NSClassFromString(@"UIRemoteKeyboardWindow")];
             UIWindow *keyboardWindow = [[[UIApplication sharedApplication].windows filteredArrayUsingPredicate:windowPredicate] firstObject];
             
@@ -38,6 +45,7 @@
                     }
                 }
             }
+             */
         }
         else {
             _keyboardViewProxy = newSuperview;

--- a/Source/SLKInputAccessoryView.m
+++ b/Source/SLKInputAccessoryView.m
@@ -27,7 +27,7 @@
     if (newSuperview) {
         if (SLK_IS_IOS9_AND_HIGHER) {
             
-            // NOTE: Because the keyboard is on its own view hiearchy since iOS 9,
+            // NOTE: Because the keyboard is on its own view hierarchy since iOS 9,
             // we needed to lookup for its view so we can move the text input whenever its origin changed.
             // We are disabling the detection of the keyboard on iOS 9 until a public API is available.
             //

--- a/Source/SLKTextView.h
+++ b/Source/SLKTextView.h
@@ -68,8 +68,10 @@ typedef NS_OPTIONS(NSUInteger, SLKPastableMediaType) {
 /** YES if quickly refreshed the textview without the intension to dismiss the keyboard. @view -disableQuicktypeBar: for more details. */
 @property (nonatomic, readwrite) BOOL didNotResignFirstResponder;
 
-/** YES if the magnifying glass is visible. */
-@property (nonatomic, getter=isLoupeVisible) BOOL loupeVisible;
+/** YES if the magnifying glass is visible.
+ This feature is deprecated since there are no legit alternatives to detect the magnifying glass.
+ */
+@property (nonatomic, getter=isLoupeVisible) BOOL loupeVisible DEPRECATED_ATTRIBUTE;
 
 /** YES if the keyboard track pad has been recognized. iOS 9 only. */
 @property (nonatomic, readonly, getter=isTrackpadEnabled) BOOL trackpadEnabled;

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -692,9 +692,14 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     // NOTE:
     // In iOS 8 and earlier, the gesture recognizer responsible for the magnifying glass movement was 'UIVariableDelayLoupeGesture'.
     // That gesture is called '_UITextSelectionForceGesture' since iOS 9.
-    // We are disabling the detection of these gesture objects until a public API is available.
     //
+    // We are disabling the detection of these gesture objects until a public API is available.
     // Open Radar: http://openradar.appspot.com/radar?id=5021485877952512
+    //
+    // From now, the isLoupeVisible flag will always be false.
+    // Whenever a user hits a range that requires auto-completion, the magnifying glass would disappear.
+    // Why, you say? Because we need to reload the textView and disable auto-correction since it overrides any
+    // auto-completion while typing.
     
     /*
     if ([gesture isMemberOfClass:NSClassFromString(@"UIVariableDelayLoupeGesture")] ||

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -697,9 +697,9 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     // Open Radar: http://openradar.appspot.com/radar?id=5021485877952512
     //
     // From now, the isLoupeVisible flag will always be false.
-    // Whenever a user hits a range that requires auto-completion, the magnifying glass would disappear.
-    // Why, you say? Because we need to reload the textView and disable auto-correction since it overrides any
-    // auto-completion while typing.
+    // Whenever a user activates the magnifying glass by long pressing on the text content area and moves the cursor into a range of text
+    // that requires auto-completion, the magnifying glass would disappear all of the sudden, causing erratic UI behaviours.
+    // Why, you say? Because we need to reload the textView and disable auto-correction since it overrides any auto-completion while typing.
     
     /*
     if ([gesture isMemberOfClass:NSClassFromString(@"UIVariableDelayLoupeGesture")] ||

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -689,12 +689,19 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 
 - (void)slk_gestureRecognized:(UIGestureRecognizer *)gesture
 {
-    // In iOS 8 and earlier, the gesture recognizer responsible for the magnifying glass movement was 'UIVariableDelayLoupeGesture'
-    // Since iOS 9, that gesture is now called '_UITextSelectionForceGesture'
+    // NOTE:
+    // In iOS 8 and earlier, the gesture recognizer responsible for the magnifying glass movement was 'UIVariableDelayLoupeGesture'.
+    // That gesture is called '_UITextSelectionForceGesture' since iOS 9.
+    // We are disabling the detection of these gesture objects until a public API is available.
+    //
+    // Open Radar: http://openradar.appspot.com/radar?id=5021485877952512
+    
+    /*
     if ([gesture isMemberOfClass:NSClassFromString(@"UIVariableDelayLoupeGesture")] ||
         [gesture isMemberOfClass:NSClassFromString(@"_UITextSelectionForceGesture")]) {
         [self slk_willShowLoupe:gesture];
     }
+     */
 }
 
 - (void)slk_willShowLoupe:(UIGestureRecognizer *)gesture

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -85,7 +85,10 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /** YES if text view's content can be cleaned with a shake gesture. Default is NO. */
 @property (nonatomic, assign) BOOL shakeToClearEnabled;
 
-/** YES if keyboard can be dismissed gradually with a vertical panning gesture. Default is YES. */
+/**
+ YES if keyboard can be dismissed gradually with a vertical panning gesture. Default is YES.
+ This feature is disabled on iOS 9 due to no legit alternatives to detect the keyboard frame.
+ */
 @property (nonatomic, assign, getter = isKeyboardPanningEnabled) BOOL keyboardPanningEnabled;
 
 /** YES if an external keyboard has been detected (this value updates only when the text view becomes first responder). */

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -908,6 +908,11 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     __block UIView *keyboardView = [self.textInputbar.inputAccessoryView keyboardViewProxy];
     
+    // When no keyboard view has been detecting, let's skip any handling.
+    if (!keyboardView) {
+        return;
+    }
+    
     // Dynamic variables
     CGPoint gestureLocation = [gesture locationInView:self.view];
     CGPoint gestureVelocity = [gesture velocityInView:self.view];


### PR DESCRIPTION
As part of not using any private API in this project, we are disabling a few features until a public API is available.

### Keyboard Panning
Because the keyboard is on its own view hierarchy since iOS 9, we needed to lookup for its view so we can move the text input whenever its origin changed. iOS 9 users won't be able to move the keyboard with the gesture anymore, even if the `keyboardPanningEnabled` is enabled. It will still work in iOS 7 and 8.

### Magnifying Glass Detection
Whenever a user activates the magnifying glass by long pressing on the text content area and moves the cursor into a range of text that requires auto-completion, the magnifying glass would disappear all of the sudden, causing erratic UI behaviours. Why, you say? Because we need to reload the textView and disable auto-correction since it overrides any auto-completion while typing.
From now, the `isLoupeVisible` flag will always be false. These erratic behavior will be back again, in any version of iOS.

The code using private APIs is still available in this project's source code, but commented out. Use it use it at your own risk.

We have filed a radar proposing new APIs to be added in `UITextInputTraits` to help making the keyboard experience better.
http://openradar.appspot.com/radar?id=5021485877952512
