### PR TITLE
Uses @dynamic instead of @synthesize

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -58,7 +58,7 @@ static NSString *const SLKTextViewGenericFormattingSelectorPrefix = @"slk_format
 @end
 
 @implementation SLKTextView
-@synthesize delegate = _delegate;
+@dynamic delegate;
 
 #pragma mark - Initialization
 


### PR DESCRIPTION
So the auto property is implemented by the super class.
Fixes #349 causing not forwarding all `UITextViewDelegate` callbacks