### PR TITLE
Implements an alternative technique for dragging the keyboard on iOS 9

### DIFF
--- a/Source/SLKInputAccessoryView.m
+++ b/Source/SLKInputAccessoryView.m
@@ -20,14 +20,11 @@
 
 @implementation SLKInputAccessoryView
 
-
 #pragma mark - Super Overrides
 
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
-    if (!SLK_IS_IOS9_AND_HIGHER) {
-        _keyboardViewProxy = newSuperview;
-    }
+    _keyboardViewProxy = newSuperview;
 }
 
 @end

--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -123,12 +123,12 @@ typedef NS_ENUM(NSUInteger, SLKCounterPosition) {
 - (void)endTextEdition;
 
 /**
- YES if a keyboard snapshot should be shown, replacing the system keyboard.
+ YES if a keyboard snapshot placeholder should be shown, replacing the system keyboard.
  The snapshot is being added as a subview, aligned at the same position the keyboard is, before hiding it momentarily.
  
- @param show YES if a keyboard snapshot should be show and the system keyboard hidden.
+ @param show YES if a keyboard snapshot placeholder should show instead of the system keyboard.
  */
-- (void)showKeyboardSnapshot:(BOOL)show;
+- (void)showKeyboardPlaceholder:(BOOL)show;
 
 
 #pragma mark - Text Counting

--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -128,12 +128,12 @@ typedef NS_ENUM(NSUInteger, SLKCounterPosition) {
  
  @param view The view where the snapshot is taken for, for aligning purposes.
  */
-- (void)showKeyboardPlaceholderFromView:(UIView *)view;
+- (void)prepareKeyboardPlaceholderFromView:(UIView *)view;
 
 /**
  Hides the visible keyboard snapshot placeholder, if applicable.
  */
-- (void)hideKeyboardPlaceholder;
+- (void)showKeyboardPlaceholder:(BOOL)show;
 
 
 #pragma mark - Text Counting

--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -123,6 +123,15 @@ typedef NS_ENUM(NSUInteger, SLKCounterPosition) {
 - (void)endTextEdition;
 
 
+/**
+ YES if a keyboard screenshot should be shown, replacing the keyboard area.
+ Since the keyboard is on its own view hierarchy since iOS 9, this is an easy technique to achieve the effect for dragging keyboard being moved together with the text input bar.
+ 
+ @param show YES if a keyboard screenshot should be show.
+ */
+- (void)showKeyboardMockup:(BOOL)show;
+
+
 #pragma mark - Text Counting
 ///------------------------------------------------
 /// @name Text Counting

--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -123,12 +123,17 @@ typedef NS_ENUM(NSUInteger, SLKCounterPosition) {
 - (void)endTextEdition;
 
 /**
- YES if a keyboard snapshot placeholder should be shown, replacing the system keyboard.
+ Shows a keyboard snapshot placeholder, replacing the system keyboard.
  The snapshot is being added as a subview, aligned at the same position the keyboard is, before hiding it momentarily.
  
- @param show YES if a keyboard snapshot placeholder should show instead of the system keyboard.
+ @param view The view where the snapshot is taken for, for aligning purposes.
  */
-- (void)showKeyboardPlaceholder:(BOOL)show;
+- (void)showKeyboardPlaceholderFromView:(UIView *)view;
+
+/**
+ Hides the visible keyboard snapshot placeholder, if applicable.
+ */
+- (void)hideKeyboardPlaceholder;
 
 
 #pragma mark - Text Counting

--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -122,14 +122,13 @@ typedef NS_ENUM(NSUInteger, SLKCounterPosition) {
  */
 - (void)endTextEdition;
 
-
 /**
- YES if a keyboard screenshot should be shown, replacing the keyboard area.
- Since the keyboard is on its own view hierarchy since iOS 9, this is an easy technique to achieve the effect for dragging keyboard being moved together with the text input bar.
+ YES if a keyboard snapshot should be shown, replacing the system keyboard.
+ The snapshot is being added as a subview, aligned at the same position the keyboard is, before hiding it momentarily.
  
- @param show YES if a keyboard screenshot should be show.
+ @param show YES if a keyboard snapshot should be show and the system keyboard hidden.
  */
-- (void)showKeyboardMockup:(BOOL)show;
+- (void)showKeyboardSnapshot:(BOOL)show;
 
 
 #pragma mark - Text Counting

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -39,7 +39,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 @property (nonatomic, strong) NSArray *charCountLabelVCs;
 
 @property (nonatomic, strong) UILabel *charCountLabel;
-@property (nonatomic, strong) UIView *keyboardMockView;
+@property (nonatomic, strong) UIView *keyboardPlaceholderView;
 
 @property (nonatomic) CGPoint previousOrigin;
 
@@ -539,41 +539,41 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 }
 
 
-#pragma mark - Keyboard Snapshot
+#pragma mark - Keyboard Snapshot Placeholder
 
-- (void)showKeyboardSnapshot:(BOOL)show
+- (void)showKeyboardPlaceholder:(BOOL)show
 {
     UIWindow *keyboardWindow = [self keyboardWindow];
     
-    if (!_keyboardMockView && show) {
+    if (!_keyboardPlaceholderView && show) {
         
         // Takes a snapshot of the keyboard's window
-        UIView *keyboardSnapshot = [keyboardWindow snapshotViewAfterScreenUpdates:NO];
+        UIView *snapshotView = [keyboardWindow snapshotViewAfterScreenUpdates:NO];
         
         // Shifts the snapshot up to fit to the bottom
-        CGRect snapshowFrame = keyboardSnapshot.frame;
+        CGRect snapshowFrame = snapshotView.frame;
         snapshowFrame.origin.y = CGRectGetHeight(self.inputAccessoryView.keyboardViewProxy.frame) - CGRectGetHeight(self.superview.frame);
-        keyboardSnapshot.frame = snapshowFrame;
+        snapshotView.frame = snapshowFrame;
         
         CGRect mockframe = self.inputAccessoryView.keyboardViewProxy.frame;
         mockframe.origin.y = CGRectGetHeight(self.frame);
         
-        _keyboardMockView = [[UIView alloc] initWithFrame:mockframe];
-        _keyboardMockView.backgroundColor = [UIColor clearColor];
-        [_keyboardMockView addSubview:keyboardSnapshot];
+        self.keyboardPlaceholderView = [[UIView alloc] initWithFrame:mockframe];
+        self.keyboardPlaceholderView.backgroundColor = [UIColor clearColor];
+        [self.keyboardPlaceholderView addSubview:snapshotView];
         
-        // Adds the mock view to the input bar, so when it moves they are glued together
-        [self addSubview:_keyboardMockView];
+        // Adds the placeholder view to the input bar, so when it looks they are sticked together.
+        [self addSubview:self.keyboardPlaceholderView];
         
         // Let's delay hiding the keyboard's window to avoid noticeable glitches
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             keyboardWindow.hidden = YES;
         });
     }
-    else if (_keyboardMockView && !show) {
+    else if (_keyboardPlaceholderView && !show) {
         
-        [_keyboardMockView removeFromSuperview];
-        _keyboardMockView = nil;
+        [_keyboardPlaceholderView removeFromSuperview];
+        _keyboardPlaceholderView = nil;
         
         keyboardWindow.hidden = NO;
     }

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -541,12 +541,11 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
 #pragma mark - Keyboard Snapshot Placeholder
 
-- (void)showKeyboardPlaceholderFromView:(UIView *)view
+- (void)prepareKeyboardPlaceholderFromView:(UIView *)view
 {
     UIWindow *keyboardWindow = [self slk_keyboardWindow];
     
     if (!_keyboardPlaceholderView && keyboardWindow) {
-        
         // Takes a snapshot of the keyboard's window
         UIView *snapshotView = [keyboardWindow snapshotViewAfterScreenUpdates:NO];
         
@@ -563,6 +562,14 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
         self.keyboardPlaceholderView = [[UIView alloc] initWithFrame:keyboardFrame];
         self.keyboardPlaceholderView.backgroundColor = [UIColor clearColor];
         [self.keyboardPlaceholderView addSubview:snapshotView];
+    }
+}
+
+- (void)showKeyboardPlaceholder:(BOOL)show
+{
+    UIWindow *keyboardWindow = [self slk_keyboardWindow];
+    
+    if (show && self.keyboardPlaceholderView && keyboardWindow) {
         
         // Adds the placeholder view to the input bar, so when it looks they are sticked together.
         [self addSubview:self.keyboardPlaceholderView];
@@ -572,13 +579,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
             keyboardWindow.hidden = YES;
         });
     }
-}
-
-- (void)hideKeyboardPlaceholder
-{
-    UIWindow *keyboardWindow = [self slk_keyboardWindow];
-
-    if (_keyboardPlaceholderView && keyboardWindow) {
+    else if (!show && _keyboardPlaceholderView && keyboardWindow) {
         
         [_keyboardPlaceholderView removeFromSuperview];
         _keyboardPlaceholderView = nil;

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -565,8 +565,8 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
         // Adds the mock view to the input bar, so when it moves they are glued together
         [self addSubview:_keyboardMockView];
         
-        // let's delay hidding the keyboard window to avoid noticeable glitches
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // Let's delay hiding the keyboard's window to avoid noticeable glitches
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             keyboardWindow.hidden = YES;
         });
     }

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -541,24 +541,26 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
 #pragma mark - Keyboard Snapshot Placeholder
 
-- (void)showKeyboardPlaceholder:(BOOL)show
+- (void)showKeyboardPlaceholderFromView:(UIView *)view
 {
-    UIWindow *keyboardWindow = [self keyboardWindow];
+    UIWindow *keyboardWindow = [self slk_keyboardWindow];
     
-    if (!_keyboardPlaceholderView && show) {
+    if (!_keyboardPlaceholderView && keyboardWindow) {
         
         // Takes a snapshot of the keyboard's window
         UIView *snapshotView = [keyboardWindow snapshotViewAfterScreenUpdates:NO];
         
+        CGRect screenBounds = [UIScreen mainScreen].bounds;
+        
         // Shifts the snapshot up to fit to the bottom
         CGRect snapshowFrame = snapshotView.frame;
-        snapshowFrame.origin.y = CGRectGetHeight(self.inputAccessoryView.keyboardViewProxy.frame) - CGRectGetHeight(self.superview.frame);
+        snapshowFrame.origin.y = CGRectGetHeight(self.inputAccessoryView.keyboardViewProxy.frame) - CGRectGetHeight(screenBounds);
         snapshotView.frame = snapshowFrame;
         
-        CGRect mockframe = self.inputAccessoryView.keyboardViewProxy.frame;
-        mockframe.origin.y = CGRectGetHeight(self.frame);
+        CGRect keyboardFrame = self.inputAccessoryView.keyboardViewProxy.frame;
+        keyboardFrame.origin.y = CGRectGetHeight(self.frame);
         
-        self.keyboardPlaceholderView = [[UIView alloc] initWithFrame:mockframe];
+        self.keyboardPlaceholderView = [[UIView alloc] initWithFrame:keyboardFrame];
         self.keyboardPlaceholderView.backgroundColor = [UIColor clearColor];
         [self.keyboardPlaceholderView addSubview:snapshotView];
         
@@ -570,7 +572,13 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
             keyboardWindow.hidden = YES;
         });
     }
-    else if (_keyboardPlaceholderView && !show) {
+}
+
+- (void)hideKeyboardPlaceholder
+{
+    UIWindow *keyboardWindow = [self slk_keyboardWindow];
+
+    if (_keyboardPlaceholderView && keyboardWindow) {
         
         [_keyboardPlaceholderView removeFromSuperview];
         _keyboardPlaceholderView = nil;
@@ -579,7 +587,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     }
 }
 
-- (UIWindow *)keyboardWindow
+- (UIWindow *)slk_keyboardWindow
 {
     NSArray *array = [[UIApplication sharedApplication] windows];
     

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -539,9 +539,9 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 }
 
 
-#pragma mark - Keyboard Mockup
+#pragma mark - Keyboard Snapshot
 
-- (void)showKeyboardMockup:(BOOL)show
+- (void)showKeyboardSnapshot:(BOOL)show
 {
     UIWindow *keyboardWindow = [self keyboardWindow];
     

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -552,7 +552,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
         
         // Shifts the snapshot up to fit to the bottom
         CGRect snapshowFrame = keyboardSnapshot.frame;
-        snapshowFrame.origin.y = CGRectGetHeight(self.inputAccessoryView.keyboardViewProxy.frame) - CGRectGetHeight(self.controller.view.frame);
+        snapshowFrame.origin.y = CGRectGetHeight(self.inputAccessoryView.keyboardViewProxy.frame) - CGRectGetHeight(self.superview.frame);
         keyboardSnapshot.frame = snapshowFrame;
         
         CGRect mockframe = self.inputAccessoryView.keyboardViewProxy.frame;

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -91,9 +91,6 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 
 /**
  YES if keyboard can be dismissed gradually with a vertical panning gesture. Default is YES.
- 
- This feature doesn't work on iOS 9 due to no legit alternatives to detect the keyboard view.
- Open Radar: http://openradar.appspot.com/radar?id=5021485877952512
  */
 @property (nonatomic, assign, getter = isKeyboardPanningEnabled) BOOL keyboardPanningEnabled;
 

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -80,8 +80,11 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /** A single tap gesture used to dismiss the keyboard. SLKTextViewController is its delegate. */
 @property (nonatomic, readonly) UIGestureRecognizer *singleTapGesture;
 
-/** A vertical pan gesture used for bringing the keyboard from the bottom. SLKTextViewController is its delegate. */
+/** A vertical pan gesture used for moving the keyboard up and bottom. SLKTextViewController is its delegate. */
 @property (nonatomic, readonly) UIPanGestureRecognizer *verticalPanGesture;
+
+/** A vertical swipe gesture used for bringing the keyboard from the bottom. SLKTextViewController is its delegate. */
+@property (nonatomic, readonly) UISwipeGestureRecognizer *verticalSwipeGesture;
 
 /** YES if animations should have bouncy effects. Default is YES. */
 @property (nonatomic, assign) BOOL bounces;
@@ -555,6 +558,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 
 /** UIGestureRecognizerDelegate */
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer NS_REQUIRES_SUPER;
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer NS_REQUIRES_SUPER;
 
 /** UIAlertViewDelegate */
 #ifndef __IPHONE_8_0

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -989,6 +989,13 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                 keyboardView.frame = originalFrame;
             }
             
+            // Because the keyboard is on its own view hierarchy since iOS 9,
+            // we instead show a snapshot of the keyboard and hide it
+            // to give the illusion that the keyboard is being moved by the user.
+            if (SLK_IS_IOS9_AND_HIGHER) {
+                [self.textInputbar showKeyboardMockup:YES];
+            }
+            
             break;
         }
         case UIGestureRecognizerStateChanged: {
@@ -1055,6 +1062,10 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         case UIGestureRecognizerStateFailed: {
             
             if (!dragging) {
+                if (SLK_IS_IOS9_AND_HIGHER) {
+                    [self.textInputbar showKeyboardMockup:NO];
+                }
+                
                 break;
             }
             
@@ -1096,6 +1107,10 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                  presenting = NO;
                                  
                                  self.movingKeyboard = NO;
+                                 
+                                 if (SLK_IS_IOS9_AND_HIGHER) {
+                                     [self.textInputbar showKeyboardMockup:NO];
+                                 }
                              }];
             
             break;

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -958,7 +958,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                     // we instead show a snapshot of the keyboard and hide it
                     // to give the illusion that the keyboard is being moved by the user.
                     if (SLK_IS_IOS9_AND_HIGHER && gestureVelocity.y > 0) {
-                        [self.textInputbar showKeyboardMockup:YES];
+                        [self.textInputbar showKeyboardSnapshot:YES];
                     }
                     
                     originalFrame = keyboardView.frame;
@@ -1010,7 +1010,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             
             if (!dragging) {
                 if (SLK_IS_IOS9_AND_HIGHER) {
-                    [self.textInputbar showKeyboardMockup:NO];
+                    [self.textInputbar showKeyboardSnapshot:NO];
                 }
                 
                 break;
@@ -1050,7 +1050,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                  self.movingKeyboard = NO;
                                  
                                  if (SLK_IS_IOS9_AND_HIGHER) {
-                                     [self.textInputbar showKeyboardMockup:NO];
+                                     [self.textInputbar showKeyboardSnapshot:NO];
                                  }
                              }];
             

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -19,9 +19,6 @@
 
 #import "UIResponder+SLKAdditions.h"
 
-/** Feature flagged while waiting to implement a more reliable technique. */
-#define SLKBottomPanningEnabled 0
-
 #define kSLKAlertViewClearTextTag [NSStringFromClass([SLKTextViewController class]) hash]
 
 NSString * const SLKKeyboardWillShowNotification =      @"SLKKeyboardWillShowNotification";
@@ -949,23 +946,10 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     // Checking the keyboard height constant helps to disable the view constraints update on iPad when the keyboard is undocked.
     // Checking the keyboard status allows to keep the inputAccessoryView valid when still reacing the bottom of the screen.
     if (![self.textView isFirstResponder] || (self.keyboardHC.constant == 0 && self.keyboardStatus == SLKKeyboardStatusDidHide)) {
-#if SLKBottomPanningEnabled
-        if ([gesture.view isEqual:self.scrollViewProxy]) {
-            if (gestureVelocity.y > 0) {
-                return;
-            }
-            else if ((self.isInverted && ![self.scrollViewProxy slk_isAtTop]) || (!self.isInverted && ![self.scrollViewProxy slk_isAtBottom])) {
-                return;
-            }
-        }
-        
-        presenting = YES;
-#else
         if ([gesture.view isEqual:_textInputbar] && gestureVelocity.y < 0) {
             [self presentKeyboard:YES];
         }
         return;
-#endif
     }
     
     switch (gesture.state) {

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -945,6 +945,13 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             startPoint = CGPointZero;
             dragging = NO;
             
+            // Because the keyboard is on its own view hierarchy since iOS 9,
+            // we instead show a snapshot of the keyboard and hide it
+            // to give the illusion that the keyboard is being moved by the user.
+            if (SLK_IS_IOS9_AND_HIGHER && gestureVelocity.y > 0) {
+                [self.textInputbar prepareKeyboardPlaceholderFromView:self.view];
+            }
+            
             break;
         }
         case UIGestureRecognizerStateChanged: {
@@ -958,7 +965,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                     // we instead show a snapshot of the keyboard and hide it
                     // to give the illusion that the keyboard is being moved by the user.
                     if (SLK_IS_IOS9_AND_HIGHER && gestureVelocity.y > 0) {
-                        [self.textInputbar showKeyboardPlaceholderFromView:self.view];
+                        [self.textInputbar showKeyboardPlaceholder:YES];
                     }
                     
                     originalFrame = keyboardView.frame;
@@ -1010,7 +1017,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             
             if (!dragging) {
                 if (SLK_IS_IOS9_AND_HIGHER) {
-                    [self.textInputbar hideKeyboardPlaceholder];
+                    [self.textInputbar showKeyboardPlaceholder:NO];
                 }
                 
                 break;
@@ -1050,7 +1057,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                  self.movingKeyboard = NO;
                                  
                                  if (SLK_IS_IOS9_AND_HIGHER) {
-                                     [self.textInputbar hideKeyboardPlaceholder];
+                                     [self.textInputbar showKeyboardPlaceholder:NO];
                                  }
                              }];
             

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -913,7 +913,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (void)slk_didSwipeTextInputBar:(UISwipeGestureRecognizer *)gesture
 {
     if (gesture.state == UIGestureRecognizerStateEnded) {
-        if ([gesture.view isEqual:self.textInputbar]) {
+        if (!self.isPresentedInPopover && ![self ignoreTextInputbarAdjustment]) {
             [self presentKeyboard:YES];
         }
     }
@@ -921,14 +921,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)slk_didPanTextInputBar:(UIPanGestureRecognizer *)gesture
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self slk_handlePanGestureRecognizer:gesture];
-    });
-}
-
-- (void)slk_handlePanGestureRecognizer:(UIPanGestureRecognizer *)gesture
-{
-    // Local variables
     static CGPoint startPoint;
     static CGRect originalFrame;
     static BOOL dragging = NO;
@@ -1091,11 +1083,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     if (!self.isPresentedInPopover && ![self ignoreTextInputbarAdjustment]) {
         [self dismissKeyboard:YES];
     }
-}
-
-- (void)slk_didPanTextView:(UIGestureRecognizer *)gesture
-{
-    [self presentKeyboard:YES];
 }
 
 - (void)slk_performRightAction

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -948,42 +948,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     CGFloat keyboardMaxY = CGRectGetHeight(SLKKeyWindowBounds());
     CGFloat keyboardMinY = keyboardMaxY - CGRectGetHeight(keyboardView.frame);
     
-    
-    // Skips this if it's not the expected textView.
-    // Checking the keyboard height constant helps to disable the view constraints update on iPad when the keyboard is undocked.
-    // Checking the keyboard status allows to keep the inputAccessoryView valid when still reacing the bottom of the screen.
-    if (![self.textView isFirstResponder] || (self.keyboardHC.constant == 0 && self.keyboardStatus == SLKKeyboardStatusDidHide)) {
-        if ([gesture.view isEqual:_textInputbar] && gestureVelocity.y < 0) {
-            [self presentKeyboard:YES];
-        }
-        return;
-    }
-    
     switch (gesture.state) {
         case UIGestureRecognizerStateBegan: {
             
             startPoint = CGPointZero;
             dragging = NO;
             
-            if (presenting) {
-                // Let's first present the keyboard without animation
-                [self presentKeyboard:NO];
-                
-                // So we can capture the keyboard's view
-                keyboardView = [_textInputbar.inputAccessoryView keyboardViewProxy];
-                
-                originalFrame = keyboardView.frame;
-                originalFrame.origin.y = CGRectGetMaxY(self.view.frame);
-                
-                // And move the keyboard to the bottom edge
-                // TODO: Fix an occasional layout glitch when the keyboard appears for the first time.
-                keyboardView.frame = originalFrame;
-            }
-            
             // Because the keyboard is on its own view hierarchy since iOS 9,
             // we instead show a snapshot of the keyboard and hide it
             // to give the illusion that the keyboard is being moved by the user.
-            if (SLK_IS_IOS9_AND_HIGHER) {
+            if (SLK_IS_IOS9_AND_HIGHER && gestureVelocity.y > 0) {
                 [self.textInputbar showKeyboardMockup:YES];
             }
             

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -958,7 +958,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                     // we instead show a snapshot of the keyboard and hide it
                     // to give the illusion that the keyboard is being moved by the user.
                     if (SLK_IS_IOS9_AND_HIGHER && gestureVelocity.y > 0) {
-                        [self.textInputbar showKeyboardPlaceholder:YES];
+                        [self.textInputbar showKeyboardPlaceholderFromView:self.view];
                     }
                     
                     originalFrame = keyboardView.frame;
@@ -1010,7 +1010,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             
             if (!dragging) {
                 if (SLK_IS_IOS9_AND_HIGHER) {
-                    [self.textInputbar showKeyboardPlaceholder:NO];
+                    [self.textInputbar hideKeyboardPlaceholder];
                 }
                 
                 break;
@@ -1050,7 +1050,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                  self.movingKeyboard = NO;
                                  
                                  if (SLK_IS_IOS9_AND_HIGHER) {
-                                     [self.textInputbar showKeyboardPlaceholder:NO];
+                                     [self.textInputbar hideKeyboardPlaceholder];
                                  }
                              }];
             

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -958,7 +958,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                     // we instead show a snapshot of the keyboard and hide it
                     // to give the illusion that the keyboard is being moved by the user.
                     if (SLK_IS_IOS9_AND_HIGHER && gestureVelocity.y > 0) {
-                        [self.textInputbar showKeyboardSnapshot:YES];
+                        [self.textInputbar showKeyboardPlaceholder:YES];
                     }
                     
                     originalFrame = keyboardView.frame;
@@ -1010,7 +1010,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             
             if (!dragging) {
                 if (SLK_IS_IOS9_AND_HIGHER) {
-                    [self.textInputbar showKeyboardSnapshot:NO];
+                    [self.textInputbar showKeyboardPlaceholder:NO];
                 }
                 
                 break;
@@ -1050,7 +1050,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                  self.movingKeyboard = NO;
                                  
                                  if (SLK_IS_IOS9_AND_HIGHER) {
-                                     [self.textInputbar showKeyboardSnapshot:NO];
+                                     [self.textInputbar showKeyboardPlaceholder:NO];
                                  }
                              }];
             


### PR DESCRIPTION
*Because the keyboard is on its own view hierarchy since iOS 9*, we needed to lookup for its view so we could move the keyboard view following the text input using a panning gesture, using private APIs. [We no longer use private APIs](https://github.com/slackhq/SlackTextViewController/pull/344), but we needed this feature back.

#### This is an alternative technique, working in the following way:
- Whenever the panning gesture recogniser changes state to `Began`, **we take a snapshot of the keyboard window** and **add it as a subview of the textInputbar**, just below, at the same position the keyboard is.
- We then **hide the window keyboard** since it overlaps the app's window.
- Then, when dragging the textInputbar, the user will have the impression the keyboard is following, accomplishing the effect we wanted. After all, we don't need interactivity on the keyboard.
- Whenever the panning gesture recogniser changes states to either `Possible`, `Cancelled`, `Ended` or `Failed`, we **remove the keyboard mockup and unhide the keyboard window**, going back to the original layout.

This works great on iPhone and iPad. It is not needed on iOS 8 and 7, since we are able to access the keyboard view like we use to, without any private API usage.

Here's the result:
![keyboard_panning2](https://cloud.githubusercontent.com/assets/590579/12302925/a50847b0-b9dc-11e5-8605-94874190b2b5.gif)
