### PR TITLE
Silence a warning about `nextLineCaretRect`

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -1030,7 +1030,7 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     UITextPosition *checkPosition = position;
     UITextPosition *closestPosition = position;
     CGRect startingCaretRect = [self caretRectForPosition:position];
-    CGRect nextLineCaretRect;
+    CGRect nextLineCaretRect = CGRectZero;
     BOOL isInNextLine = NO;
     
     while (YES) {


### PR DESCRIPTION
The Xcode (7.3 beta 1) error/warning I'm seeing is:

> SlackTextViewController/SLKTextView.m:1057:75: Variable 'nextLineCaretRect' may be uninitialized when used here

This seems like a worthwhile change, regardless of whether there's a currently possible code path which results in reading `nextLineCaretRect` before it's initialized with a value.