### PR TITLE
Update license year range to 2016

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-   Copyright 2015 Slack Technologies, Inc.
+   Copyright 2014-2016 Slack Technologies, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright

Therefore added a range between 2014-2016