### PR TITLE
use the intrinsic content size of the right button in SLKTextInputBar

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -344,17 +344,8 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
         }
     }
 
-    NSString *title = [self.rightButton titleForState:UIControlStateNormal];
-
-    CGSize rightButtonSize;
+    CGSize rightButtonSize = [self.rightButton intrinsicContentSize];
     
-    if ([title length] == 0 && self.rightButton.imageView.image) {
-        rightButtonSize = self.rightButton.imageView.image.size;
-    }
-    else {
-        rightButtonSize = [title sizeWithAttributes:@{NSFontAttributeName: self.rightButton.titleLabel.font}];
-    }
-
     return rightButtonSize.width + self.contentInset.right;
 }
 


### PR DESCRIPTION
This change will take padding from custom content and title insets set for the rightButton when sizing the width of the rightButton.