### PR TITLE
Presents the auto-completion view on top of the table/collection view

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -2158,7 +2158,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                             @"textInputbar": self.textInputbar,
                             };
     
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[scrollView(0@750)][autoCompletionView(0@750)][typingIndicatorView(0)]-0@999-[textInputbar(0)]-0-|" options:0 metrics:nil views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[scrollView(0@750)][typingIndicatorView(0)]-0@999-[textInputbar(0)]|" options:0 metrics:nil views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[autoCompletionView(0@750)][typingIndicatorView]" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[scrollView]|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[autoCompletionView]|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[typingIndicatorView]|" options:0 metrics:nil views:views]];


### PR DESCRIPTION
The way the auto-completion view has always been presented used to be a bit violent/intrusive, by moving up and down the table/collection view at every character change, specially if the auto-completion view's height was being resized dynamically based on the amount of cells to be displayed.
This feels definetly much better, presenting it now on top of the table/collection view.

![untitled2](https://cloud.githubusercontent.com/assets/590579/12874797/4899fdb0-cdba-11e5-896f-319c02dc1fe0.gif)

Closes #381