### PR TITLE
add a property to allow ignoring tabbar height when adjusting input view

### DIFF
--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -120,6 +120,9 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /** YES if the view controller is presented inside of a popover controller. If YES, the keyboard won't move the text input bar and tapping on the tableView/collectionView will not cause the keyboard to be dismissed. This property is compatible only with iPad. */
 @property (nonatomic, assign, getter = isPresentedInPopover) BOOL presentedInPopover;
 
+// Default is YES. Set to NO to prevent the textbar adjusting incorrectly when building more customized behavior
+@property (nonatomic, assign) BOOL adjustsForTabBar;
+
 /** Convenience accessors (accessed through the text input bar) */
 @property (nonatomic, readonly) SLKTextView *textView;
 @property (nonatomic, readonly) UIButton *leftButton;

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -161,7 +161,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     self.keyboardPanningEnabled = YES;
     self.shouldClearTextAtRightButtonPress = YES;
     self.shouldScrollToBottomAfterKeyboardShows = NO;
-    
+    self.adjustsForTabBar = YES;
+
     self.automaticallyAdjustsScrollViewInsets = YES;
     self.extendedLayoutIncludesOpaqueBars = YES;
 }
@@ -415,7 +416,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (CGFloat)slk_appropriateBottomMargin
 {
     // A bottom margin is required only if the view is extended out of it bounds
-    if ((self.edgesForExtendedLayout & UIRectEdgeBottom) > 0) {
+    if (self.adjustsForTabBar && (self.edgesForExtendedLayout & UIRectEdgeBottom) > 0) {
         
         UITabBar *tabBar = self.tabBarController.tabBar;
         


### PR DESCRIPTION
In the particular use case I found this necessary, I am using SlackTextViewController in a containing view controller that requires a tabbar. When presenting STVC, the text input field would end up vertically displaced from the keyboard by the height of the tabbar. This pull request addresses and allows for preventing that from happening.