### PR TITLE
Make dismissTextInputBar method public

### DIFF
--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -379,12 +379,10 @@
 
 - (void)didPressRightButton:(id)sender
 {
-    [self dismissTextInputbar:true];
-    [super didPressRightButton:sender];
     // Notifies the view controller when the right button's action has been triggered, manually or by using the keyboard return key.
     
     // This little trick validates any pending auto-correction or auto-spelling just after hitting the 'Send' button
-    /*[self.textView refreshFirstResponder];
+    [self.textView refreshFirstResponder];
     
     Message *message = [Message new];
     message.username = [LoremIpsum name];
@@ -405,7 +403,7 @@
     // See https://github.com/slackhq/SlackTextViewController/issues/94#issuecomment-69929927
     [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
     
-    [super didPressRightButton:sender];*/
+    [super didPressRightButton:sender];
 }
 
 - (void)didPressArrowKey:(id)sender

--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -379,10 +379,12 @@
 
 - (void)didPressRightButton:(id)sender
 {
+    [self dismissTextInputbar:true];
+    [super didPressRightButton:sender];
     // Notifies the view controller when the right button's action has been triggered, manually or by using the keyboard return key.
     
     // This little trick validates any pending auto-correction or auto-spelling just after hitting the 'Send' button
-    [self.textView refreshFirstResponder];
+    /*[self.textView refreshFirstResponder];
     
     Message *message = [Message new];
     message.username = [LoremIpsum name];
@@ -403,7 +405,7 @@
     // See https://github.com/slackhq/SlackTextViewController/issues/94#issuecomment-69929927
     [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
     
-    [super didPressRightButton:sender];
+    [super didPressRightButton:sender];*/
 }
 
 - (void)didPressArrowKey:(id)sender

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -213,8 +213,10 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  
  The recommended method to use is forceTextInputbarAdjustmentForResponder:
  Only if that doesn't dismiss the textInputBar should this be used.
+ 
+ @param animated YES if the textInputBar should be dismissed using an animation.
  */
-- (void)dismissTextInputbarIfNeeded;
+- (void)dismissTextInputbar:(BOOL)animated;
 
 /**
  Verifies if the text input bar should still move up/down even if it is not first responder. Default is NO.

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -209,6 +209,14 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)dismissKeyboard:(BOOL)animated;
 
 /**
+ Dimisses the text input bar, if not already
+ 
+ The recommend method to use is forceTextInputbarAdjustmentForResponder:
+ only if that dosent dismiss the textInputBar should this be used.
+ */
+- (void)dismissTextInputbarIfNeeded;
+
+/**
  Verifies if the text input bar should still move up/down even if it is not first responder. Default is NO.
  You can override this method to perform additional tasks associated with presenting the view.
  You don't need call super since this method doesn't do anything.

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -209,10 +209,10 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)dismissKeyboard:(BOOL)animated;
 
 /**
- Dimisses the text input bar, if not already
+ Dismisses the text input bar, if not already
  
- The recommend method to use is forceTextInputbarAdjustmentForResponder:
- only if that dosent dismiss the textInputBar should this be used.
+ The recommended method to use is forceTextInputbarAdjustmentForResponder:
+ Only if that doesn't dismiss the textInputBar should this be used.
  */
 - (void)dismissTextInputbarIfNeeded;
 

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1355,7 +1355,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             return;
         }
         else if (![self forceTextInputbarAdjustmentForResponder:currentResponder]) {
-            return [self dismissTextInputbar:false];
+            return [self dismissTextInputbar:NO];
         }
     }
     

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -900,11 +900,12 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     __weak typeof(self) weakSelf = self;
     
+    [self slk_hideAutoCompletionViewIfNeeded];
+    
     void (^animations)() = ^void(){
         
         weakSelf.keyboardHC.constant = 0.0;
         weakSelf.scrollViewHC.constant = [weakSelf slk_appropriateScrollViewHeight];
-        [weakSelf slk_hideAutoCompletionViewIfNeeded];
 
         [weakSelf.view layoutIfNeeded];
     };

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -904,20 +904,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         
         weakSelf.keyboardHC.constant = 0.0;
         weakSelf.scrollViewHC.constant = [weakSelf slk_appropriateScrollViewHeight];
+        [weakSelf slk_hideAutoCompletionViewIfNeeded];
 
         [weakSelf.view layoutIfNeeded];
     };
     
-    void (^completion)(BOOL finished) = ^void(BOOL finished){
-        [weakSelf slk_hideAutoCompletionViewIfNeeded];
-    };
-    
     if (animated) {
-        [UIView animateWithDuration:0.25 animations:animations completion:completion];
+        [UIView animateWithDuration:0.25 animations:animations completion:nil];
     }
     else {
         animations();
-        completion(NO);
     }
 }
 

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -892,6 +892,20 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     }
 }
 
+- (void)dismissTextInputbarIfNeeded
+{
+    if (self.keyboardHC.constant == 0) {
+        return;
+    }
+    
+    self.keyboardHC.constant = 0.0;
+    self.scrollViewHC.constant = [self slk_appropriateScrollViewHeight];
+    
+    [self slk_hideAutoCompletionViewIfNeeded];
+    
+    [self.view layoutIfNeeded];
+}
+
 
 #pragma mark - Private Methods
 
@@ -1160,20 +1174,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     [self.textView setTypingSuggestionEnabled:enable];
 }
 
-- (void)slk_dismissTextInputbarIfNeeded
-{
-    if (self.keyboardHC.constant == 0) {
-        return;
-    }
-    
-    self.keyboardHC.constant = 0.0;
-    self.scrollViewHC.constant = [self slk_appropriateScrollViewHeight];
-    
-    [self slk_hideAutoCompletionViewIfNeeded];
-    
-    [self.view layoutIfNeeded];
-}
-
 - (void)slk_detectKeyboardStatesInNotification:(NSNotification *)notification
 {
     // Tear down
@@ -1343,7 +1343,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             return;
         }
         else if (![self forceTextInputbarAdjustmentForResponder:currentResponder]) {
-            return [self slk_dismissTextInputbarIfNeeded];
+            return [self dismissTextInputbarIfNeeded];
         }
     }
     

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -892,18 +892,33 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     }
 }
 
-- (void)dismissTextInputbarIfNeeded
+- (void)dismissTextInputbar:(BOOL)animated
 {
     if (self.keyboardHC.constant == 0) {
         return;
     }
     
-    self.keyboardHC.constant = 0.0;
-    self.scrollViewHC.constant = [self slk_appropriateScrollViewHeight];
+    __weak typeof(self) weakSelf = self;
     
-    [self slk_hideAutoCompletionViewIfNeeded];
+    void (^animations)() = ^void(){
+        
+        weakSelf.keyboardHC.constant = 0.0;
+        weakSelf.scrollViewHC.constant = [weakSelf slk_appropriateScrollViewHeight];
+
+        [weakSelf.view layoutIfNeeded];
+    };
     
-    [self.view layoutIfNeeded];
+    void (^completion)(BOOL finished) = ^void(BOOL finished){
+        [weakSelf slk_hideAutoCompletionViewIfNeeded];
+    };
+    
+    if (animated) {
+        [UIView animateWithDuration:0.25 animations:animations completion:completion];
+    }
+    else {
+        animations();
+        completion(NO);
+    }
 }
 
 
@@ -1343,7 +1358,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             return;
         }
         else if (![self forceTextInputbarAdjustmentForResponder:currentResponder]) {
-            return [self dismissTextInputbarIfNeeded];
+            return [self dismissTextInputbar:false];
         }
     }
     


### PR DESCRIPTION
Exposing this public method as a last resort if using forceTextInputbarAdjustmentForResponder: isn't a good fit.

An example of such a cases is 3D Touch on iOS 9.2. If the keybaord is open and you 3D touch to view a link; upon closing the webview, the keyboard is resigned but the textInputBar stays in the middle of the screen instead of at the bottom, as expected.

![img_1552](https://cloud.githubusercontent.com/assets/2206858/12993998/62c843f2-d0d2-11e5-9909-e766756ade7f.PNG)
