### PR TITLE
Animate views when switching from the a keyboard to a custom input view.

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1372,6 +1372,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         [self slk_hideAutoCompletionViewIfNeeded];
     }
     
+    // store the previous keyboard height
+    CGFloat preKeyboardHeight = self.keyboardHC.constant;
+
     // Updates the height constraints' constants
     self.keyboardHC.constant = [self slk_appropriateKeyboardHeightFromNotification:notification];
     self.scrollViewHC.constant = [self slk_appropriateScrollViewHeight];
@@ -1397,7 +1400,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     // Begin and end frames are the same when the keyboard is shown during navigation controller's push animation.
     // The animation happens in window coordinates (slides from right to left) but doesn't in the view controller's view coordinates.
-    if (!CGRectEqualToRect(beginFrame, endFrame))
+    // Second condition: check if the height of the keyboard changed.
+    if (!CGRectEqualToRect(beginFrame, endFrame) || fabs(preKeyboardHeight - self.keyboardHC.constant) >= FLT_EPSILON)
     {
         // Only for this animation, we set bo to bounce since we want to give the impression that the text input is glued to the keyboard.
         [self.view slk_animateLayoutIfNeededWithDuration:duration


### PR DESCRIPTION
Hello, 

I found there's a "jump" when setting the `inputView` property of the text view:

<img src="https://cloud.githubusercontent.com/assets/1046917/13776202/dbe67ba2-eae3-11e5-8914-822b4a1c3c65.gif" alt="Without Animation" style="height: 360px;"/>

It looks like the value of `UIKeyboardFrameBeginUserInfoKey` and `UIKeyboardFrameEndUserInfoKey` are the same when `reloadInputViews` is called after setting a custom `inputView`.

So I add a condition to check if the height of the keyboard changed.

This is the result after the modification:

<img src="https://cloud.githubusercontent.com/assets/1046917/13776212/eebe7ab8-eae3-11e5-9594-2829d70f1280.gif" alt="With Animation" style="height: 360px;"/>
 

Looking forward to your feedback. 