### PR TITLE
Text input placeholder fix

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -433,6 +433,13 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     [self refreshFirstResponder];
 }
 
+- (void)setContentOffset:(CGPoint)contentOffset
+{
+    // At times during a layout pass, the content offset's x value may change.
+    // Since we only care about vertical offset, let's override its horizontal value to avoid other layout issues.
+    [super setContentOffset:CGPointMake(0.0, contentOffset.y)];
+}
+
 
 #pragma mark - UITextView Overrides
 

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -2131,7 +2131,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                             };
     
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[scrollView(0@750)][textInputbar(0)]|" options:0 metrics:nil views:views]];
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[typingIndicatorView(0)]-0@999-[textInputbar]|" options:0 metrics:nil views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[typingIndicatorView(0)][textInputbar]" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[autoCompletionView(0@750)][typingIndicatorView]" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[scrollView]|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[autoCompletionView]|" options:0 metrics:nil views:views]];


### PR DESCRIPTION
At times during a layout pass, the content offset's x value may change.
This was causing the textView's placeholder and its text layout to be misaligned and out of bounds, specially reproducible when starting/ending the auto-completion mode.

Also fixes a regression recently introduced with the typing indicator layout tweaks in https://github.com/slackhq/SlackTextViewController/pull/429.