### PR TITLE
Actually, let's not check for currentResponder

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1326,11 +1326,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     UIResponder *currentResponder = [UIResponder slk_currentFirstResponder];
     
-    // Detects the current first responder. Ignores these notifications when no valid responder is detected.
-    if (!currentResponder) {
-        return;
-    }
-    
     // Skips if it's not the expected textView and shouldn't force adjustment of the text input bar.
     // This will also dismiss the text input bar if it's visible, and exit auto-completion mode if enabled.
     if (![currentResponder isEqual:self.textView] && ![self forceTextInputbarAdjustmentForResponder:currentResponder]) {


### PR DESCRIPTION
Leave it to the subclass to handle it.