### PR TITLE
UITabbarController size check slk_dismissTextInputbarIfNeeded

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1166,11 +1166,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)slk_dismissTextInputbarIfNeeded
 {
-    if (self.keyboardHC.constant == 0) {
+    CGFloat bottom = 0;
+    if (self.tabBarController) {
+        bottom = self.tabBarController.tabBar.frame.size.height;
+    }
+    
+    if (self.keyboardHC.constant == bottom) {
         return;
     }
     
-    self.keyboardHC.constant = 0.0;
+    self.keyboardHC.constant = bottom;
     self.scrollViewHC.constant = [self slk_appropriateScrollViewHeight];
     
     [self slk_hideAutoCompletionViewIfNeeded];


### PR DESCRIPTION
When using the UITabbarController,
input bar covered in the tab bar
i'm fixed
