### PR TITLE
Fixed bottom margin

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -195,7 +195,10 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     [UIView performWithoutAnimation:^{
         // Reloads any cached text
         [self slk_reloadTextView];
-    }];
+	}];
+	
+	// when our tabBarController changes we need to update for a possible new bottom margin
+	[self slk_updateViewConstraints];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -235,13 +238,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
-}
-
-- (void)didMoveToParentViewController:(UIViewController *)parent {
-    [super didMoveToParentViewController:parent];
-    
-    // when our tabBarController changes we need to update for a possible new bottom margin
-    [self slk_updateViewConstraints];
 }
 
 

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -237,6 +237,13 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     [super viewDidLayoutSubviews];
 }
 
+- (void)didMoveToParentViewController:(UIViewController *)parent {
+    [super didMoveToParentViewController:parent];
+    
+    // when our tabBarController changes we need to update for a possible new bottom margin
+    [self slk_updateViewConstraints];
+}
+
 
 #pragma mark - Getters
 


### PR DESCRIPTION
There were a couple of situations where the bottom text bar could be behind the tab bar related to the view being loaded and laid out before it was in a tab bar controller.

This forces constraints to be updated after any parent view controllers change.