### PR TITLE
Doesn't stop from showing the typing indicator

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -794,11 +794,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         return NO;
     }
     
-    // Don't show if the content offset is not at top (when inverted) or at bottom (when not inverted)
-    if ((self.isInverted && ![self.scrollViewProxy slk_isAtTop]) || (!self.isInverted && ![self.scrollViewProxy slk_isAtBottom])) {
-        return NO;
-    }
-    
     return YES;
 }
 


### PR DESCRIPTION
...regardless if the scrolling cursor is at the bottom or not.

Fixes #474