### PR TITLE
Fixes crash when auto-completing with the dictation input mode

### DIFF
--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -495,7 +495,7 @@
 
 - (BOOL)shouldProcessTextForAutoCompletion:(NSString *)text
 {
-    return YES;
+    return [super shouldProcessTextForAutoCompletion:text];
 }
 
 - (void)didChangeAutoCompletionPrefix:(NSString *)prefix andWord:(NSString *)word

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -876,7 +876,7 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 
 - (void)slk_willShowMenuController:(NSNotification *)notification
 {
-    
+    // Do something
 }
 
 - (void)slk_didHideMenuController:(NSNotification *)notification

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1154,9 +1154,17 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     BOOL enable = !self.isAutoCompleting;
     
+    NSString *inputPrimaryLanguage = self.textView.textInputMode.primaryLanguage;
+
     // Toggling autocorrect on Japanese keyboards breaks autocompletion by replacing the autocompletion prefix by an empty string.
     // So for now, let's not disable autocorrection for Japanese.
-    if ([self.textView.textInputMode.primaryLanguage isEqualToString:@"ja-JP"]) {
+    if ([inputPrimaryLanguage isEqualToString:@"ja-JP"]) {
+        return;
+    }
+    
+    // Let's avoid refreshing the text view while dictation mode is enabled.
+    // This solves a crash some users were experiencing when auto-completing with the dictation input mode.
+    if ([inputPrimaryLanguage isEqualToString:@"dictation"]) {
         return;
     }
     


### PR DESCRIPTION
Solves a crash some users were experiencing when auto-completing with the dictation input mode.
This PR adds a way to detect the dictation mode, using `UITextInputMode` public API. Once detected, we can opt-out from refreshing the text view.

It was causing the following exception:
```
Fatal Exception: NSInternalInconsistencyException NSInternalInconsistencyException
We were never set up properly to stream in this document.
```