### PR TITLE
Removes unnecessary NS_DESIGNATED_INITIALIZER macro

### DIFF
--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -135,7 +135,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  @param style A constant that specifies the style of main table view that the controller object is to manage (UITableViewStylePlain or UITableViewStyleGrouped).
  @return An initialized SLKTextViewController object or nil if the object could not be created.
  */
-- (instancetype)initWithTableViewStyle:(UITableViewStyle)style SLK_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTableViewStyle:(UITableViewStyle)style;
 
 /**
  Initializes a collection view controller and configures the collection view with the provided layout.
@@ -144,7 +144,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  @param layout The layout object to associate with the collection view. The layout controls how the collection view presents its cells and supplementary views.
  @return An initialized SLKTextViewController object or nil if the object could not be created.
  */
-- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout SLK_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout;
 
 /**
  Initializes a text view controller to manage an arbitraty scroll view. The caller is responsible for configuration of the scroll view, including wiring the delegate.
@@ -152,7 +152,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  @param a UISCrollView to be used as the main content area.
  @return An initialized SLKTextViewController object or nil if the object could not be created.
  */
-- (instancetype)initWithScrollView:(UIScrollView *)scrollView SLK_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScrollView:(UIScrollView *)scrollView;
 
 /**
  Initializes either a table or collection view controller.
@@ -161,7 +161,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  @param decoder An unarchiver object.
  @return An initialized SLKTextViewController object or nil if the object could not be created.
  */
-- (instancetype)initWithCoder:(NSCoder *)decoder SLK_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder *)decoder;
 
 /**
  Returns the tableView style to be configured when using Interface Builder. Default is UITableViewStylePlain.

--- a/Source/SLKUIConstants.h
+++ b/Source/SLKUIConstants.h
@@ -18,10 +18,6 @@
 
 #define SLK_KEYBOARD_NOTIFICATION_DEBUG     DEBUG && 0  // Logs every keyboard notification being sent
 
-#if __has_attribute(objc_designated_initializer)
-    #define SLK_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
-#endif
-
 static NSString *SLKTextViewControllerDomain = @"com.slack.TextViewController";
 
 /**


### PR DESCRIPTION
Specially annoying if a subclass of `SLKTextViewController` has its own designated initialiser, a bunch of warnings will be fired up.