### PR TITLE
Prevent the placeholder label from getting voice over focus

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -143,6 +143,7 @@ static NSString *const SLKTextViewGenericFormattingSelectorPrefix = @"slk_format
         _placeholderLabel.backgroundColor = [UIColor clearColor];
         _placeholderLabel.textColor = [UIColor lightGrayColor];
         _placeholderLabel.hidden = YES;
+        _placeholderLabel.isAccessibilityElement = NO;
         
         [self addSubview:_placeholderLabel];
     }


### PR DESCRIPTION
Currently if you turn on voice over, focus on the upload button and swipe right twice, it focuses on the placeholder label. The text input should just be a single accessibility element.