### PR TITLE
Fixes the keyboard state updates. Fixes #487

### DIFF
--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -377,7 +377,12 @@
 {
     // Notifies the view controller that the keyboard changed status.
     
-    NSLog(@"didChangeKeyboardStatus : %ld", status);
+    switch (status) {
+        case SLKKeyboardStatusWillShow:     return NSLog(@"Will Show");
+        case SLKKeyboardStatusDidShow:      return NSLog(@"Did Show");
+        case SLKKeyboardStatusWillHide:     return NSLog(@"Will Hide");
+        case SLKKeyboardStatusDidHide:      return NSLog(@"Did Hide");
+    }
 }
 
 - (void)textWillUpdate

--- a/Examples/Messenger-Shared/MessageViewController.m
+++ b/Examples/Messenger-Shared/MessageViewController.m
@@ -376,6 +376,8 @@
 - (void)didChangeKeyboardStatus:(SLKKeyboardStatus)status
 {
     // Notifies the view controller that the keyboard changed status.
+    
+    NSLog(@"didChangeKeyboardStatus : %ld", status);
 }
 
 - (void)textWillUpdate
@@ -397,6 +399,12 @@
     // Notifies the view controller when the left button's action has been triggered, manually.
     
     [super didPressLeftButton:sender];
+    
+    UIViewController *vc = [UIViewController new];
+    vc.view.backgroundColor = [UIColor whiteColor];
+    vc.title = @"Details";
+    
+    [self.navigationController pushViewController:vc animated:YES];
 }
 
 - (void)didPressRightButton:(id)sender

--- a/Examples/Messenger-Swift/Base.lproj/Main.storyboard
+++ b/Examples/Messenger-Swift/Base.lproj/Main.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="jPN-Ft-lgW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="jPN-Ft-lgW">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--Message View Controller-->
+        <!--Message Thread-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="MessageViewController" customModule="Messenger_Swift" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Message Thread" id="BYZ-38-t0r" customClass="MessageViewController" customModule="Messenger_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -19,10 +19,31 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" id="Kuo-HA-7nc"/>
+                    <connections>
+                        <segue destination="kwe-Wv-66Y" kind="show" identifier="Push" id="rAO-Fs-P9l"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1213" y="478"/>
+        </scene>
+        <!--Message Detail-->
+        <scene sceneID="EBE-UJ-9Eg">
+            <objects>
+                <viewController title="Message Detail" id="kwe-Wv-66Y" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="08R-wf-6EQ"/>
+                        <viewControllerLayoutGuide type="bottom" id="9ks-NF-Vcp"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="KMe-76-E1y">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Qla-sV-EqK" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1977" y="478"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Tsc-df-QmC">

--- a/Examples/Messenger-Swift/MessageViewController.swift
+++ b/Examples/Messenger-Swift/MessageViewController.swift
@@ -354,7 +354,16 @@ extension MessageViewController {
     
     // Notifies the view controller that the keyboard changed status.
     override func didChangeKeyboardStatus(status: SLKKeyboardStatus) {
-        // So something
+        switch status {
+        case .WillShow:
+            print("Will Show")
+        case .DidShow:
+            print("Did Show")
+        case .WillHide:
+            print("Will Hide")
+        case .DidHide:
+            print("Did Hide")
+        }
     }
     
     // Notifies the view controller that the text will update.
@@ -370,6 +379,9 @@ extension MessageViewController {
     // Notifies the view controller when the left button's action has been triggered, manually.
     override func didPressLeftButton(sender: AnyObject!) {
         super.didPressLeftButton(sender)
+        
+        self.dismissKeyboard(true)
+        self.performSegueWithIdentifier("Push", sender: nil)
     }
     
     // Notifies the view controller when the right button's action has been triggered, manually or by using the keyboard return key.

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1312,8 +1312,10 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)slk_willShowOrHideKeyboard:(NSNotification *)notification
 {
+    SLKKeyboardStatus status = [self slk_keyboardStatusForNotification:notification];
+    
     // Skips if the view isn't visible.
-    if (!self.view.window) {
+    if (!self.isViewVisible) {
         return;
     }
     
@@ -1335,8 +1337,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         [self slk_dismissTextInputbarIfNeeded];
         return;
     }
-    
-    SLKKeyboardStatus status = [self slk_keyboardStatusForNotification:notification];
     
     // Skips if it's the current status
     if (self.keyboardStatus == status) {
@@ -1404,9 +1404,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)slk_didShowOrHideKeyboard:(NSNotification *)notification
 {
+    SLKKeyboardStatus status = [self slk_keyboardStatusForNotification:notification];
+    
     // Skips if the view isn't visible
-    if (!self.view.window) {
-        return;
+    if (!self.isViewVisible) {
+        if (status == SLKKeyboardStatusDidHide && self.keyboardStatus == SLKKeyboardStatusWillHide) {
+            // Even if the view isn't visible anymore, let's still continue to update all states.
+        }
+        else {
+            return;
+        }
     }
     
     // Skips if it is presented inside of a popover
@@ -1418,8 +1425,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     if (self.textView.didNotResignFirstResponder) {
         return;
     }
-    
-    SLKKeyboardStatus status = [self slk_keyboardStatusForNotification:notification];
     
     // Skips if it's the current status
     if (self.keyboardStatus == status) {


### PR DESCRIPTION
Doesn't skip keyboard status update if the view isn't visible anymore, at least when needed.
Fixes #487

Also updates the sample project to open a new view from the left button for testing purposes.