### PR TITLE
Supporting Attributed String in SLKTextView

### DIFF
--- a/Source/SLKTextView+SLKAdditions.h
+++ b/Source/SLKTextView+SLKAdditions.h
@@ -47,6 +47,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)slk_insertTextAtCaretRange:(NSString *)text;
 
 /**
+ Insert a string at the caret's position with stylization from the attributes.
+ 
+ @param text The string to be appended to the current text.
+ @param attributes The attributes used to stylize the text.
+ */
+- (void)slk_insertTextAtCaretRange:(NSString *)text
+                    withAttributes:(NSDictionary<NSString *, id> *)attributes;
+
+/**
  Adds a string to a specific range.
  
  @param text The string to be appended to the current text.
@@ -55,6 +64,55 @@ NS_ASSUME_NONNULL_BEGIN
  @return The range of the newly inserted text.
  */
 - (NSRange)slk_insertText:(NSString *)text inRange:(NSRange)range;
+
+/**
+ Adds a string to a specific range, with stylization from the attributes.
+ 
+ @param text The string to be appended to the current text.
+ @param attributes The attributes used to stylize the text.
+ @param range The range where to insert text.
+ 
+ @return The range of the newly inserted text.
+ */
+- (NSRange)slk_insertText:(NSString *)text
+           withAttributes:(NSDictionary<NSString *, id> *)attributes
+                  inRange:(NSRange)range;
+
+/**
+ Sets the text attributes for the attributed string in the provided range.
+ 
+ @param attributes The attributes used to style NSAttributedString class.
+ @param range The range of the text that needs to be stylized by the given attributes.
+ 
+ @return The attributedText with updated attributes.
+ */
+- (NSAttributedString *)slk_setAttribute:(NSDictionary<NSString *, id> *)attributes
+                                 inRange:(NSRange)range;
+
+/**
+ Inserts an attributed string at the caret's position.
+ 
+ @param text The string to be appended to the current text.
+ */
+- (void)slk_insertAttributedTextAtCaretRange:(NSAttributedString *)attributedText;
+
+/**
+ Adds an attributed string to a specific range.
+ 
+ @param text The string to be appended to the current text.
+ @param range The range where to insert text.
+ 
+ @return The range of the newly inserted text.
+ */
+- (NSRange)slk_insertAttributedText:(NSAttributedString *)attributedText inRange:(NSRange)range;
+
+/**
+ Remove all attributed string attributes from the text for the given range
+ 
+ @param range The range to remove the attributes.
+ */
+
+- (void)slk_clearAllAttributesInRange:(NSRange)range;
 
 /**
  Registers the current text for future undo actions.

--- a/Source/SLKTextView+SLKAdditions.h
+++ b/Source/SLKTextView+SLKAdditions.h
@@ -71,7 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
  @param text The string to be appended to the current text.
  @param attributes The attributes used to stylize the text.
  @param range The range where to insert text.
- 
  @return The range of the newly inserted text.
  */
 - (NSRange)slk_insertText:(NSString *)text
@@ -83,8 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param attributes The attributes used to style NSAttributedString class.
  @param range The range of the text that needs to be stylized by the given attributes.
- 
- @return The attributedText with updated attributes.
+ @return An attributed string.
  */
 - (NSAttributedString *)slk_setAttributes:(NSDictionary<NSString *, id> *)attributes
                                   inRange:(NSRange)range;
@@ -92,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Inserts an attributed string at the caret's position.
  
- @param text The string to be appended to the current text.
+ @param attributedText The attributed string to be appended.
  */
 - (void)slk_insertAttributedTextAtCaretRange:(NSAttributedString *)attributedText;
 
@@ -101,18 +99,24 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param text The string to be appended to the current text.
  @param range The range where to insert text.
- 
  @return The range of the newly inserted text.
  */
 - (NSRange)slk_insertAttributedText:(NSAttributedString *)attributedText inRange:(NSRange)range;
 
 /**
- Remove all attributed string attributes from the text for the given range
+ Removes all attributed string attributes from the text view, for the given range.
  
  @param range The range to remove the attributes.
  */
-
 - (void)slk_clearAllAttributesInRange:(NSRange)range;
+
+/**
+ Returns a default attributed string, using the text view's font and text color.
+ 
+ @param text The string to be used for creating a new attributed string.
+ @return An attributed string.
+ */
+- (NSAttributedString *)slk_defaultAttributedStringForText:(NSString *)text;
 
 /**
  Registers the current text for future undo actions.

--- a/Source/SLKTextView+SLKAdditions.h
+++ b/Source/SLKTextView+SLKAdditions.h
@@ -86,8 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return The attributedText with updated attributes.
  */
-- (NSAttributedString *)slk_setAttribute:(NSDictionary<NSString *, id> *)attributes
-                                 inRange:(NSRange)range;
+- (NSAttributedString *)slk_setAttributes:(NSDictionary<NSString *, id> *)attributes
+                                  inRange:(NSRange)range;
 
 /**
  Inserts an attributed string at the caret's position.

--- a/Source/SLKTextView+SLKAdditions.m
+++ b/Source/SLKTextView+SLKAdditions.m
@@ -88,8 +88,8 @@
     return [self slk_insertAttributedText:attributedText inRange:range];
 }
 
-- (NSAttributedString *)slk_setAttribute:(NSDictionary<NSString *, id> *)attributes
-                                 inRange:(NSRange)range
+- (NSAttributedString *)slk_setAttributes:(NSDictionary<NSString *, id> *)attributes
+                                  inRange:(NSRange)range
 {
     NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
     

--- a/Source/SLKTextView+SLKAdditions.m
+++ b/Source/SLKTextView+SLKAdditions.m
@@ -67,8 +67,7 @@
     self.selectedRange = NSMakeRange(range.location, 0);
 }
 
-- (void)slk_insertTextAtCaretRange:(NSString *)text
-                    withAttributes:(NSDictionary<NSString *, id> *)attributes
+- (void)slk_insertTextAtCaretRange:(NSString *)text withAttributes:(NSDictionary<NSString *, id> *)attributes
 {
     NSRange range = [self slk_insertText:text withAttributes:attributes inRange:self.selectedRange];
     self.selectedRange = NSMakeRange(range.location, 0);
@@ -76,15 +75,15 @@
 
 - (NSRange)slk_insertText:(NSString *)text inRange:(NSRange)range
 {
-    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text];
+    NSAttributedString *attributedText = [self slk_defaultAttributedStringForText:text];
+    
     return [self slk_insertAttributedText:attributedText inRange:range];
 }
 
-- (NSRange)slk_insertText:(NSString *)text
-           withAttributes:(NSDictionary<NSString *, id> *)attributes
-                  inRange:(NSRange)range
+- (NSRange)slk_insertText:(NSString *)text withAttributes:(NSDictionary<NSString *, id> *)attributes inRange:(NSRange)range
 {
     NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text attributes:attributes];
+    
     return [self slk_insertAttributedText:attributedText inRange:range];
 }
 
@@ -95,6 +94,7 @@
     
     [attributedText setAttributes:attributes range:range];
     [self setAttributedText:attributedText];
+    
     return self.attributedText;
 }
 
@@ -154,6 +154,21 @@
     
     [mutableAttributedText setAttributes:nil range:range];
     [self setAttributedText:mutableAttributedText];
+}
+
+- (NSAttributedString *)slk_defaultAttributedStringForText:(NSString *)text
+{
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    
+    if (self.textColor) {
+        attributes[NSForegroundColorAttributeName] = self.textColor;
+    }
+    
+    if (self.font) {
+        attributes[NSFontAttributeName] = self.font;
+    }
+        
+    return [[NSAttributedString alloc] initWithString:text attributes:attributes];
 }
 
 - (void)slk_prepareForUndo:(NSString *)description

--- a/Source/SLKTextView+SLKAdditions.m
+++ b/Source/SLKTextView+SLKAdditions.m
@@ -13,7 +13,8 @@
 - (void)slk_clearText:(BOOL)clearUndo
 {
     // Important to call self implementation, as SLKTextView overrides setText: to add additional features.
-    [self setText:nil];
+    
+    [self setAttributedText:nil];
     
     if (self.undoManagerEnabled && clearUndo) {
         [self.undoManager removeAllActions];
@@ -66,40 +67,93 @@
     self.selectedRange = NSMakeRange(range.location, 0);
 }
 
+- (void)slk_insertTextAtCaretRange:(NSString *)text
+                    withAttributes:(NSDictionary<NSString *, id> *)attributes
+{
+    NSRange range = [self slk_insertText:text withAttributes:attributes inRange:self.selectedRange];
+    self.selectedRange = NSMakeRange(range.location, 0);
+}
+
 - (NSRange)slk_insertText:(NSString *)text inRange:(NSRange)range
 {
-    // Skip if the text is empty
-    if (text.length == 0) {
+    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text];
+    return [self slk_insertAttributedText:attributedText inRange:range];
+}
+
+- (NSRange)slk_insertText:(NSString *)text
+           withAttributes:(NSDictionary<NSString *, id> *)attributes
+                  inRange:(NSRange)range
+{
+    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text attributes:attributes];
+    return [self slk_insertAttributedText:attributedText inRange:range];
+}
+
+- (NSAttributedString *)slk_setAttribute:(NSDictionary<NSString *, id> *)attributes
+                                 inRange:(NSRange)range
+{
+    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
+    
+    [attributedText setAttributes:attributes range:range];
+    [self setAttributedText:attributedText];
+    return self.attributedText;
+}
+
+- (void)slk_insertAttributedTextAtCaretRange:(NSAttributedString *)attributedText
+{
+    NSRange range = [self slk_insertAttributedText:attributedText inRange:self.selectedRange];
+    self.selectedRange = NSMakeRange(range.location, 0);
+}
+
+- (NSRange)slk_insertAttributedText:(NSAttributedString *)attributedText inRange:(NSRange)range
+{
+    // Skip if the attributed text is empty
+    if (attributedText.length == 0) {
         return NSMakeRange(0, 0);
     }
     
     // Registers for undo management
-    [self slk_prepareForUndo:@"Text appending"];
+    [self slk_prepareForUndo:@"Attributed text appending"];
     
     // Append the new string at the caret position
     if (range.length == 0)
     {
-        NSString *leftString = [self.text substringToIndex:range.location];
-        NSString *rightString = [self.text substringFromIndex: range.location];
+        NSAttributedString *leftAttributedString = [self.attributedText attributedSubstringFromRange:NSMakeRange(0, range.location)];
         
-        self.text = [NSString stringWithFormat:@"%@%@%@", leftString, text, rightString];
+        NSAttributedString *rightAttributedString = [self.attributedText attributedSubstringFromRange:NSMakeRange(range.location, self.attributedText.length-range.location)];
         
-        range.location += text.length;
-
+        NSMutableAttributedString *newAttributedText = [NSMutableAttributedString new];
+        [newAttributedText appendAttributedString:leftAttributedString];
+        [newAttributedText appendAttributedString:attributedText];
+        [newAttributedText appendAttributedString:rightAttributedString];
+        
+        [self setAttributedText:newAttributedText];
+        range.location += attributedText.length;
+        
         return range;
     }
     // Some text is selected, so we replace it with the new text
     else if (range.location != NSNotFound && range.length > 0)
     {
-        self.text = [self.text stringByReplacingCharactersInRange:range withString:text];
-
-        range.location += text.length;
+        NSMutableAttributedString *mutableAttributeText = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
+        
+        [mutableAttributeText replaceCharactersInRange:range withAttributedString:attributedText];
+    
+        [self setAttributedText:mutableAttributeText];
+        range.location += self.attributedText.length;
         
         return range;
     }
     
     // No text has been inserted, but still return the caret range
     return self.selectedRange;
+}
+
+- (void)slk_clearAllAttributesInRange:(NSRange)range
+{
+    NSMutableAttributedString *mutableAttributedText = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
+    
+    [mutableAttributedText setAttributes:nil range:range];
+    [self setAttributedText:mutableAttributedText];
 }
 
 - (void)slk_prepareForUndo:(NSString *)description

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -454,7 +454,9 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     [self slk_prepareForUndo:@"Text Set"];
 
     if (text) {
-        [self setAttributedText:[[NSAttributedString alloc] initWithString:text]];
+        [self setAttributedText:[[NSAttributedString alloc] initWithString:text
+                                                                attributes:@{NSFontAttributeName: self.font,
+                                                                             NSForegroundColorAttributeName: self.textColor}]];
     } else {
         [self setAttributedText:nil];
     }

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -450,16 +450,14 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 
 - (void)setText:(NSString *)text
 {
-    if (!text) {
-        return;
-    }
-
     // Registers for undo management
     [self slk_prepareForUndo:@"Text Set"];
-    
-    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text];
-    
-    [self setAttributedText:attributedText];
+
+    if (text) {
+        [self setAttributedText:[[NSAttributedString alloc] initWithString:text]];
+    } else {
+        [self setAttributedText:nil];
+    }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:self];
 }

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -454,9 +454,7 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     [self slk_prepareForUndo:@"Text Set"];
 
     if (text) {
-        [self setAttributedText:[[NSAttributedString alloc] initWithString:text
-                                                                attributes:@{NSFontAttributeName: self.font,
-                                                                             NSForegroundColorAttributeName: self.textColor}]];
+        [self setAttributedText:[self slk_defaultAttributedStringForText:text]];
     } else {
         [self setAttributedText:nil];
     }

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -450,12 +450,23 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 
 - (void)setText:(NSString *)text
 {
+    if (!text) {
+        return;
+    }
+
     // Registers for undo management
     [self slk_prepareForUndo:@"Text Set"];
     
-    [super setText:text];
+    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text];
+    
+    [self setAttributedText:attributedText];
     
     [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:self];
+}
+
+- (NSString *)text
+{
+    return self.attributedText.string;
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText


### PR DESCRIPTION
We wanted to support attributed string in our SLKTextView to allow more stylization on the text we input. This PR will change SLKTextView to use NSAttributedString by default. To be backward compatible, all the original API will be preserved, and in places where we insert NSString for the text, the string will be converted into NSAttributedString without any attributes assigned to it.
There are additional API provided to allow ease of stylization. 
