### PR TITLE
Uses the new editAttributedText: method internally for editText:

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -464,7 +464,8 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 
     if (text) {
         [self setAttributedText:[self slk_defaultAttributedStringForText:text]];
-    } else {
+    }
+    else {
         [self setAttributedText:nil];
     }
     

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -467,17 +467,15 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  */
 - (void)showAutoCompletionView:(BOOL)show;
 
-
 /**
  Use this method to programatically show the autocompletion view, with provided prefix and word to search.
  Right before the view is shown, -reloadData is called. So avoid calling it manually.
  
- @param prefix a prefix that is used to trigger autocompletion
- @param word a word to search for autocompletion
- @param prefixRange range in which prefix spans.
+ @param prefix A prefix that is used to trigger autocompletion
+ @param word A word to search for autocompletion
+ @param prefixRange The range in which prefix spans.
 */
 - (void)showAutoCompletionViewWithPrefix:(NSString *)prefix andWord:(NSString *)word prefixRange:(NSRange)prefixRange;
-
 
 /**
  Returns a custom height for the autocompletion view. Default is 0.0.

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -742,22 +742,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)editText:(NSString *)text
 {
-    if (![_textInputbar canEditText:text]) {
-        return;
-    }
-    
-    // Caches the current text, in case the user cancels the edition
-    [self slk_cacheTextToDisk:self.textView.text];
-    
-    [_textInputbar beginTextEditing];
-    
-    // Setting the text after calling -beginTextEditing is safer
-    [self.textView setText:text];
-    
-    [self.textView slk_scrollToCaretPositonAnimated:YES];
-    
-    // Brings up the keyboard if needed
-    [self presentKeyboard:YES];
+    NSAttributedString *attributedText = [self.textView slk_defaultAttributedStringForText:text];
+    [self editAttributedText:attributedText];
 }
 
 - (void)editAttributedText:(NSAttributedString *)attributedText


### PR DESCRIPTION
Uses the new `editAttributedText:` method internally for `editText:`.
This helps reducing duplicated logic in 
