### PR TITLE
Exposed slk_cacheTextView

### DIFF
--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -544,7 +544,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 /**
  Caches text to disk.
  */
-- (void)slk_cacheTextView;
+- (void)cacheTextView;
 
 
 #pragma mark - Customization

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -541,6 +541,11 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
  */
 + (void)clearAllCachedText;
 
+/**
+ Caches text to disk.
+ */
+- (void)slk_cacheTextView;
+
 
 #pragma mark - Customization
 ///------------------------------------------------

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1812,7 +1812,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     }
 }
 
-- (void)slk_cacheTextView
+- (void)cacheTextView
 {
     [self slk_cacheAttributedTextToDisk:self.textView.attributedText];
 }


### PR DESCRIPTION
Exposed slk_cacheTextView so that it can be used in cases where full view lifecycle is not called.
