### PR TITLE
Alway force hide autocompletion menu when calling cancleAutoCompletion.

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1700,7 +1700,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     [self.textView lookForPrefixes:self.registeredPrefixes
                         completion:^(NSString *prefix, NSString *word, NSRange wordRange) {
                             
-                            if (prefix.length > 0 && word.length > 0) {
+                            if (prefix && prefix.length > 0 && word.length > 0) {
                                 
                                 // Captures the detected symbol prefix
                                 _foundPrefix = prefix;

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1686,7 +1686,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (void)cancelAutoCompletion
 {
     [self slk_invalidateAutoCompletion];
-    [self slk_hideAutoCompletionViewIfNeeded];
+    [self showAutoCompletionView:NO];
 }
 
 - (void)slk_processTextForAutoCompletion


### PR DESCRIPTION
I ran into a strange bug where `self.isAutoCompleting` is set to NO and the foundPrefix and foundWord are nil, yet the auto-completion table view still shows with one empty roll. 

It seems like calling cancelAutoCompletion did not take effect because it checks the self.isAutoCompleting flag first. Still uncertain how we ended up in this stage, but I think as the name of the method `cancelAutoCompletion` implies, we should always force to cancel the auto completion menu.