### PR TITLE
Added ability to register a custom NSTextStorage class for input

### DIFF
--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) SLKTextView *textView;
 
+@property (nonatomic, strong) NSTextStorage *textStorage;
+
 /** The custom input accessory view, used as empty achor view to detect the keyboard frame. */
 @property (nonatomic, strong) SLKInputAccessoryView *inputAccessoryView;
 
@@ -67,12 +69,15 @@ NS_ASSUME_NONNULL_BEGIN
 ///------------------------------------------------
 
 /**
- Initializes a text input bar with a class to be used for the text view
+ Initializes a text input bar with classes to be used for the text view, and its text storage
  
  @param textViewClass The class to be used when creating the text view. May be nil. If provided, the class must be a subclass of SLKTextView
+ @param textStorageClass The class to be used when creating the text view's text storage. May be nil.
+
  @return An initialized SLKTextInputbar object or nil if the object could not be created.
  */
-- (instancetype)initWithTextViewClass:(Class)textViewClass;
+
+- (instancetype)initWithTextViewClass:(Class)textViewClass textStorageClass:(Class)textStorageClass;
 
 
 #pragma mark - Text Editing

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -35,6 +35,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 @property (nonatomic) CGPoint previousOrigin;
 
 @property (nonatomic, strong) Class textViewClass;
+@property (nonatomic, strong) Class textStorageClass;
 
 @property (nonatomic, getter=isHidden) BOOL hidden; // Required override
 
@@ -45,10 +46,11 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
 #pragma mark - Initialization
 
-- (instancetype)initWithTextViewClass:(Class)textViewClass
+- (instancetype)initWithTextViewClass:(Class)textViewClass textStorageClass:(Class)textStorageClass
 {
     if (self = [super init]) {
         self.textViewClass = textViewClass;
+        self.textStorageClass = textStorageClass;
         [self slk_commonInit];
     }
     return self;
@@ -129,7 +131,25 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     if (!_textView) {
         Class class = self.textViewClass ? : [SLKTextView class];
         
-        _textView = [[class alloc] init];
+        if (self.textStorageClass) {
+            _textStorage = [[self.textStorageClass alloc] init];
+           
+            NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+            
+            NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeZero];
+            container.heightTracksTextView = YES;
+            container.widthTracksTextView = YES;
+            
+            [layoutManager addTextContainer:container];
+            
+            [_textStorage addLayoutManager:layoutManager];
+            
+            _textView = [[class alloc]initWithFrame:CGRectZero textContainer:container];
+        }
+        else {
+            _textView = [[class alloc] init];
+        }
+        
         _textView.translatesAutoresizingMaskIntoConstraints = NO;
         _textView.font = [UIFont systemFontOfSize:15.0];
         _textView.maxNumberOfLines = [self slk_defaultNumberOfLines];

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -561,6 +561,15 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)registerClassForTextView:(Class _Nullable)aClass;
 
 /**
+ Registers a class to be used as the text storage for the text view.
+ You need to call this method inside of any initialization method.
+ 
+ @param aClass An NSTextStorage subclass.
+ */
+- (void)registerClassForTextStorage:(Class _Nullable)aClass;
+
+
+/**
  Registers a class for customizing the behavior and appearance of the typing indicator view.
  You need to call this method inside of any initialization method.
  Make sure to conform to SLKTypingIndicatorProtocol and implement the required methods.

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -54,6 +54,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 // Optional classes to be used instead of the default ones.
 @property (nonatomic, strong) Class textViewClass;
+@property (nonatomic, strong) Class textStorageClass;
+
 @property (nonatomic, strong) Class typingIndicatorViewClass;
 
 @end
@@ -306,7 +308,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 - (SLKTextInputbar *)textInputbar
 {
     if (!_textInputbar) {
-        _textInputbar = [[SLKTextInputbar alloc] initWithTextViewClass:self.textViewClass];
+        _textInputbar = [[SLKTextInputbar alloc] initWithTextViewClass:self.textViewClass textStorageClass:self.textStorageClass];
+                         
         _textInputbar.translatesAutoresizingMaskIntoConstraints = NO;
         
         [_textInputbar.leftButton addTarget:self action:@selector(didPressLeftButton:) forControlEvents:UIControlEventTouchUpInside];
@@ -1903,6 +1906,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     self.textViewClass = aClass;
 }
 
+- (void)registerClassForTextStorage:(Class)aClass
+{
+    if (aClass == nil) {
+        return;
+    }
+    
+    NSAssert([aClass isSubclassOfClass:[NSTextStorage class]], @"The registered class is invalid, it must be a subclass of NSTextStorage.");
+    self.textStorageClass = aClass;
+}
+
 - (void)registerClassForTypingIndicatorView:(Class)aClass
 {
     if (aClass == nil) {
@@ -2387,6 +2400,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     _textInputbar = nil;
     _textViewClass = nil;
+    _textStorageClass = nil;
     
     [_typingIndicatorProxyView removeObserver:self forKeyPath:@"visible"];
     _typingIndicatorProxyView = nil;


### PR DESCRIPTION
I wanted to be able to use a custom NSTextStorage subclass with the input textView, so I added this in. 

This is probably an edge use-case, but it's optional to use, just like custom subclasses for the textView itself.

Regards,
Arvindh 