### PR TITLE
Scroll up under inverted=NO when keyboard shows

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -28,6 +28,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 {
     CGPoint _scrollViewOffsetBeforeDragging;
     CGFloat _keyboardHeightBeforeDragging;
+    CGPoint _textViewPointBeforeEditing;
+    BOOL _viewAtButtomBeforeEditing;
 }
 
 // The shared scrollView pointer, either a tableView or collectionView
@@ -2031,6 +2033,15 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (BOOL)textViewShouldBeginEditing:(SLKTextView *)textView
 {
+    if (!_inverted && _tableView) {
+        if (_tableView.contentOffset.y >= (_tableView.contentSize.height - _tableView.frame.size.height)) {
+            //user has scrolled to the bottom
+            _viewAtButtomBeforeEditing = YES;
+        } else {
+            _viewAtButtomBeforeEditing = NO;
+            _textViewPointBeforeEditing = [textView.superview convertPoint:textView.frame.origin toView: self.view];
+        }
+    }
     return YES;
 }
 
@@ -2041,6 +2052,19 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 
 - (void)textViewDidBeginEditing:(SLKTextView *)textView
 {
+    if (!_inverted && _tableView) {
+        CGPoint textViewPoint = [textView.superview convertPoint:textView.frame.origin toView: self.view];
+        CGPoint contentOffset = _tableView.contentOffset;
+        if (_viewAtButtomBeforeEditing) {
+            CGFloat y = _tableView.contentSize.height - _tableView.frame.size.height;
+            if (y > 0) {
+                contentOffset.y = y;
+            }
+        } else {
+            contentOffset.y += _textViewPointBeforeEditing.y - textViewPoint.y;
+        }
+        [_tableView setContentOffset:contentOffset animated:YES];
+    }
     // No implementation here. Meant to be overriden in subclass.
 }
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Scroll up to current place when keyboard shows

#### Related Issues
Try to fix #333