### PR TITLE
Solved problem with iOS Margin Bottom iOS 10

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -196,6 +196,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         // Reloads any cached text
         [self slk_reloadTextView];
     }];
+    
+    [self setAutomaticallyAdjustsScrollViewInsets:NO];
+    [[self tableView] setContentInset:UIEdgeInsetsZero];
 }
 
 - (void)viewDidAppear:(BOOL)animated


### PR DESCRIPTION
* [ ] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> e.g. New functionality for producing whatsits.

#### Related Issues
> e.g. Fixes #206 and closes #230

#### Test strategy
> e.g. Add tests around whatsit production.
When you're using a custom tableViewCell you will get the bottom space on iOS, if you add these lines before on ViewWillAppear fixed the bottom margin, please see my issue on:

https://github.com/slackhq/SlackTextViewController/issues/515