### PR TITLE
Fix Typo in clearCachedText comment

### DIFF
--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -531,7 +531,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (nullable NSString *)keyForTextCaching;
 
 /**
- Removes the current's vien controller cached text.
+ Removes the current view controller's cached text.
  To enable this, you must return a valid key string in -keyForTextCaching.
  */
 - (void)clearCachedText;


### PR DESCRIPTION
* [ X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X ] I've written tests to cover the new code and functionality included in this PR.
* [X ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> There was a typo ("vien" instead of "view") and the wording was a bit unclear.

#### Related Issues
> Did not open an issue

#### Test strategy
> No test needed, only comment updated
