### PR TITLE
Fixed scroll offset adjustment due to inputBarHeight change being don…

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -665,6 +665,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     if (inputbarHeight != self.textInputbarHC.constant)
     {
         CGFloat inputBarHeightDelta = inputbarHeight - self.textInputbarHC.constant;
+        CGPoint newOffset = CGPointMake(0, self.scrollViewProxy.contentOffset.y + inputBarHeightDelta);
         self.textInputbarHC.constant = inputbarHeight;
         self.scrollViewHC.constant = [self slk_appropriateScrollViewHeight];
         
@@ -678,7 +679,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                                    options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
                                                 animations:^{
                                                     if (!self.isInverted) {
-                                                        self.scrollViewProxy.contentOffset = CGPointMake(0, self.scrollViewProxy.contentOffset.y + inputBarHeightDelta);
+                                                        self.scrollViewProxy.contentOffset = newOffset;
                                                     }
                                                     if (weakSelf.textInputbar.isEditing) {
                                                         [weakSelf.textView slk_scrollToCaretPositonAnimated:NO];


### PR DESCRIPTION
Follow up on https://github.com/slackhq/SlackTextViewController/pull/532

When increasing the height constraint of a scrollview and calling layout on it, _adjustContentOffsetIfNecessary is called which adjusts the content offset so that there's no blank space at the bottom. When this happens, the content offset adjustment would happen twice, once by _adjustContentOffsetIfNecessary and once by the code in the block.

Have the adjustment be based on the contentOffset before any layout so that it remains accurate.