### PR TITLE
Fix README inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,8 @@ Some layouts may require to show from bottom to top and new subviews are inserte
 ```swift
 override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         
-    if let cell = tableView.dequeueReusableCellWithIdentifier(kAutoCompletionCellIdentifier) {
-        cell.textLabel!.text = self.searchResult[indexPath.row]
-        return cell
+    if let cell = tableView.dequeueReusableCellWithIdentifier(kCellIdentifier) {
+        cell.transform = self.tableView.transform
     }
 }
 ```


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Fix README inconsistency: The Obj-C example were different than the Swift one.