### PR TITLE
Call registerClass before super.viewDidLoad() in swift code

### DIFF
--- a/Examples/Messenger-Swift/MessageViewController.swift
+++ b/Examples/Messenger-Swift/MessageViewController.swift
@@ -40,8 +40,11 @@ class MessageViewController: SLKTextViewController {
     func commonInit() {
         
         NotificationCenter.default.addObserver(self.tableView, selector: #selector(UITableView.reloadData), name: NSNotification.Name.UIContentSizeCategoryDidChange, object: nil)
-        NotificationCenter.default.addObserver(self,  selector: #selector(MessageViewController.textInputbarDidMove(_:)), name: NSNotification.Name.SLKTextInputbarDidMove, object: nil)
-        
+        NotificationCenter.default.addObserver(self,  selector: #selector(MessageViewController.textInputbarDidMove(_:)), name: NSNotification.Name.SLKTextInputbarDidMove, object: nil)        
+    }
+    
+    override func viewDidLoad() {
+
         // Register a SLKTextView subclass, if you need any special appearance and/or behavior customisation.
         self.registerClass(forTextView: MessageTextView.classForCoder())
         
@@ -49,10 +52,7 @@ class MessageViewController: SLKTextViewController {
             // Register a UIView subclass, conforming to SLKTypingIndicatorProtocol, to use a custom typing indicator view.
             self.registerClass(forTypingIndicatorView: TypingIndicatorView.classForCoder())
         }
-    }
-    
-    override func viewDidLoad() {
-        
+
         super.viewDidLoad()
         
         self.commonInit()


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Call registerClass earlier, otherwise default classes are used
 
#### Related Issues
Fixes #509 
