### PR TITLE
Do not show the "Format" item if this feature is not being used.

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -740,9 +740,15 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 {
     UIMenuItem *undo = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"Undo", nil) action:@selector(slk_undo:)];
     UIMenuItem *redo = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"Redo", nil) action:@selector(slk_redo:)];
-    UIMenuItem *format = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"Format", nil) action:@selector(slk_presentFormattingMenu:)];
     
-    [[UIMenuController sharedMenuController] setMenuItems:@[undo, redo, format]];
+    NSMutableArray *items = [NSMutableArray arrayWithObjects:undo, redo, nil];
+    
+    if (self.registeredFormattingTitles.count > 0) {
+        UIMenuItem *format = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"Format", nil) action:@selector(slk_presentFormattingMenu:)];
+        [items addObject:format];
+    }
+    
+    [[UIMenuController sharedMenuController] setMenuItems:items];
 }
 
 - (void)slk_undo:(id)sender


### PR DESCRIPTION
This caused a state error where the menu would stop appearing after "Format" is
tapped but there were no items to display. slk_didHideMenuController: was never
called to reset self.formatting = NO because the menu never appeared.