### PR TITLE
Added concrete targets in Podfile to work with Cocoapods 1.0.0 onwards.

### DIFF
--- a/Examples/Podfile
+++ b/Examples/Podfile
@@ -3,6 +3,23 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'Messenger.xcworkspace'
 platform :ios, '7.0'
 
-pod 'SlackTextViewController', :path => '../SlackTextViewController.podspec'
+def shared_pods
+    pod 'SlackTextViewController', :path => '../SlackTextViewController.podspec'
+      pod 'LoremIpsum', '~> 1.0'
+end
 
-pod 'LoremIpsum', '~> 1.0'
+target 'Messenger-Programatic' do
+    shared_pods
+end
+
+target 'Messenger-Storyboard' do
+    shared_pods
+end
+
+target 'Messenger-Swift' do
+    shared_pods
+end
+
+target 'Messenger-iPad-Sheet' do
+    shared_pods
+end


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).


This fixes the error:

```
[!] The dependency `SlackTextViewController (from `../SlackTextViewController.podspec`)` is not used in any concrete target.
The dependency `LoremIpsum (~> 1.0)` is not used in any concrete target.
```

 when doing `pod install` in the "Examples" folder using Cocoapods version 1.0 onwards.