### PR TITLE
Allowing the customization of the highlighted items in the typing indicator

### DIFF
--- a/Source/SLKTypingIndicatorView.h
+++ b/Source/SLKTypingIndicatorView.h
@@ -23,6 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The color of the text. Default is grayColor. */
 @property (nonatomic, strong) UIColor *textColor;
 
+/** The color of the highlighted text. Default is grayColor. */
+@property (nonatomic, strong) UIColor *highlightTextColor;
+
 /** The font of the text. Default is system font, 12 pts. */
 @property (nonatomic, strong) UIFont *textFont;
 

--- a/Source/SLKTypingIndicatorView.m
+++ b/Source/SLKTypingIndicatorView.m
@@ -57,6 +57,7 @@
     self.timers = [NSMutableArray new];
     
     self.textColor = [UIColor grayColor];
+    self.highlightTextColor = [UIColor grayColor];
     self.textFont = [UIFont systemFontOfSize:12.0];
     self.highlightFont = [UIFont boldSystemFontOfSize:12.0];
     self.contentInset = UIEdgeInsetsMake(10.0, 40.0, 10.0, 10.0);
@@ -146,6 +147,8 @@
     if (self.usernames.count <= 2) {
         [attributedString addAttribute:NSFontAttributeName value:self.highlightFont range:[text rangeOfString:firstObject]];
         [attributedString addAttribute:NSFontAttributeName value:self.highlightFont range:[text rangeOfString:lastObject]];
+        [attributedString addAttribute:NSForegroundColorAttributeName value:self.highlightTextColor range:[text rangeOfString:firstObject]];
+        [attributedString addAttribute:NSForegroundColorAttributeName value:self.highlightTextColor range:[text rangeOfString:lastObject]];
     }
     
     return attributedString;


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This feature allows the customization of the highlighted text color inside the typing indicator view