### PR TITLE
Solve a problem with the new sdk on iOS 11 that causes an extra space…

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -186,11 +186,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 {
     [super viewWillAppear:animated];
     
-    // Deactivate automatic scrollView adjustment
-    if (@available(iOS 11.0, *)) {
-        self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-    }
-    
     // Invalidates this flag when the view appears
     self.textView.didNotResignFirstResponder = NO;
     

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -264,6 +264,11 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         _tableView.dataSource = self;
         _tableView.delegate = self;
         _tableView.clipsToBounds = NO;
+        
+        // Deactivate automatic scrollView adjustment
+        if (@available(iOS 11.0, *)) {
+            _tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+        }
     }
     return _tableView;
 }

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -186,6 +186,11 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 {
     [super viewWillAppear:animated];
     
+    // Deactivate automatic scrollView adjustment
+    if (@available(iOS 11.0, *)) {
+        self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
+    
     // Invalidates this flag when the view appears
     self.textView.didNotResignFirstResponder = NO;
     


### PR DESCRIPTION
… in the bottom due to automatic content inset adjustment.

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> Apple added in the sdk for iOS 11 a new property in ScrollViews that causes automatic inset adjustment by default (https://developer.apple.com/videos/play/wwdc2017/204/). This PR pretends to disable this property to avoid an extra space in the inverted tableView.

#### Related Issues
> Fixes #630 