### PR TITLE
Keep scroll view content inset adjustment

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -259,11 +259,8 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         _tableView.dataSource = self;
         _tableView.delegate = self;
         _tableView.clipsToBounds = NO;
-        
-        // Deactivate automatic scrollView adjustment
-        if (@available(iOS 11.0, *)) {
-            _tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-        }
+
+        [self slk_updateInsetAdjustmentBehavior];
     }
     return _tableView;
 }
@@ -565,6 +562,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     }
     
     _inverted = inverted;
+    [self slk_updateInsetAdjustmentBehavior];
     
     self.scrollViewProxy.transform = inverted ? CGAffineTransformMake(1, 0, 0, -1, 0, 0) : CGAffineTransformIdentity;
 }
@@ -574,6 +572,18 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     _bounces = bounces;
     _textInputbar.bounces = bounces;
 }
+
+- (void)slk_updateInsetAdjustmentBehavior
+    {
+        // Deactivate automatic scrollView adjustment for inverted table view
+        if (@available(iOS 11.0, *)) {
+            if (self.isInverted) {
+                _tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+            } else {
+                _tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
+            }
+        }
+    }
 
 - (BOOL)slk_updateKeyboardStatus:(SLKKeyboardStatus)status
 {


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This fixes the issue for non-inverted table views when navigation bar was overlaying it. It was caused by `_tableView.contentInsetAdjustmentBehavior` being set to `UIScrollViewContentInsetAdjustmentNever`. I added a new method `slk_updateInsetAdjustmentBehavior` which updates adjustment behavior when `isInverted` field is mutated and sets an appropriate adjustment type based on the new value.

#### Related Issues
Fixes #642 
Related to change from #631