### PR TITLE
Increase SLKTextView's influence over calculating its height.

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -310,11 +310,16 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
 - (CGFloat)appropriateHeight
 {
-    CGFloat height = self.textView.appropriateHeight;
+    CGFloat height = 0.0;
     CGFloat minimumHeight = [self minimumInputbarHeight];
     
-    height += self.contentInset.top;
-    height += self.slk_bottomMargin;
+    if (self.textView.numberOfLines == 1) {
+        height = minimumHeight;
+    } else {
+        height = self.textView.appropriateHeight;
+        height += self.contentInset.top;
+        height += self.slk_bottomMargin;
+    }
     
     if (height < minimumHeight) {
         height = minimumHeight;

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -310,18 +310,11 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
 - (CGFloat)appropriateHeight
 {
-    CGFloat height = 0.0;
+    CGFloat height = self.textView.appropriateHeight;
     CGFloat minimumHeight = [self minimumInputbarHeight];
     
-    if (self.textView.numberOfLines == 1) {
-        height = minimumHeight;
-    }
-    else if (self.textView.numberOfLines < self.textView.maxNumberOfLines) {
-        height = [self slk_inputBarHeightForLines:self.textView.numberOfLines];
-    }
-    else {
-        height = [self slk_inputBarHeightForLines:self.textView.maxNumberOfLines];
-    }
+    height += self.contentInset.top;
+    height += self.slk_bottomMargin;
     
     if (height < minimumHeight) {
         height = minimumHeight;
@@ -342,17 +335,6 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
         return YES;
     }
     return NO;
-}
-
-- (CGFloat)slk_inputBarHeightForLines:(NSUInteger)numberOfLines
-{
-    CGFloat height = self.textView.intrinsicContentSize.height;
-    height -= self.textView.font.lineHeight;
-    height += roundf(self.textView.font.lineHeight*numberOfLines);
-    height += self.contentInset.top;
-    height += self.slk_bottomMargin;
-    
-    return height;
 }
 
 - (CGFloat)slk_bottomMargin

--- a/Source/SLKTextView.h
+++ b/Source/SLKTextView.h
@@ -53,6 +53,9 @@ UIKIT_EXTERN NSString * const SLKTextViewPastedItemData;
 /** The placeholder's font. Default is the textView's font. */
 @property (nonatomic, copy, null_resettable) UIFont *placeholderFont;
 
+/** Height being multiplication of number of lines and font's line height. */
+@property(nonatomic, readonly) CGFloat appropriateHeight;
+
 /** The maximum number of lines before enabling scrolling. Default is 0 wich means limitless.
  If dynamic type is enabled, the maximum number of lines will be calculated proportionally to the user preferred font size. */
 @property (nonatomic, readwrite) NSUInteger maxNumberOfLines;

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -165,6 +165,16 @@ static NSString *const SLKTextViewGenericFormattingSelectorPrefix = @"slk_format
     return self.placeholderLabel.font;
 }
 
+- (CGFloat)appropriateHeight
+{
+    NSUInteger numberOfLines = self.numberOfLines > self.maxNumberOfLines ? self.maxNumberOfLines : self.numberOfLines;
+    CGFloat height = [self intrinsicContentSize].height;
+    height -= self.font.lineHeight;
+    height += roundf(self.font.lineHeight*numberOfLines);
+    
+    return height;
+}
+
 - (NSUInteger)numberOfLines
 {
     CGSize contentSize = self.contentSize;


### PR DESCRIPTION
* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [ ] I've added a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've listed my changes on the [Changelog(https://github.com/slackhq/SlackTextViewController/blob/master/CHANGELOG.md) file.
* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Change doesn't affect the functionality in any way. It moves SLKTextView height calculation logic to SLKTextView class itself. This adds flexibility when subclassing SLKTextView.
Example:
When adding custom line spacing using NSAttributedString and NSParagraphStyle to text in text view, there is currently no way to change its height in order to accommodate text formatted that way.
