### PR TITLE
inputbar left button: fixes text-only button not being displayed

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -105,6 +105,8 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     
     [self slk_registerTo:self.layer forSelector:@selector(position)];
     [self slk_registerTo:self.leftButton.imageView forSelector:@selector(image)];
+	[self slk_registerTo:self.leftButton.titleLabel forSelector:@selector(font)];
+	[self slk_registerTo:self.leftButton.titleLabel forSelector:@selector(text)];
     [self slk_registerTo:self.rightButton.titleLabel forSelector:@selector(font)];
 }
 
@@ -706,7 +708,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     else {
         self.editorContentViewHC.constant = zero;
         
-        CGSize leftButtonSize = [self.leftButton imageForState:self.leftButton.state].size;
+        CGSize leftButtonSize = [self.leftButton intrinsicContentSize];
         
         if (leftButtonSize.width > 0) {
             self.leftButtonHC.constant = roundf(leftButtonSize.height);
@@ -762,6 +764,11 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
             [self slk_updateConstraintConstants];
         }
     }
+	else if ([object isEqual:self.leftButton.titleLabel] &&
+			 ([keyPath isEqualToString:NSStringFromSelector(@selector(font))]
+			  || [keyPath isEqualToString:NSStringFromSelector(@selector(text))])) {
+		[self slk_updateConstraintConstants];
+	}
     else if ([object isEqual:self.rightButton.titleLabel] && [keyPath isEqualToString:NSStringFromSelector(@selector(font))]) {
         
         [self slk_updateConstraintConstants];


### PR DESCRIPTION
#### PR Summary
> Fixes that left button is not displayed when using only the button label but no image.
> When using only a label for the left button it previously wasn't displayed at all.
> This was due to constraints recalculation was only done when the image is changed but not when the label is changed.
> Now label is monitored for changes too and constraints are coreetly updated therefore displaying text-only buttons corretly.



#### Test strategy
> Replace the image of the left button with some text. Previous version won't show the button this one will.
