### PR TITLE
Fix README typo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ If the user selects any autocompletion view cell on `tableView:didSelectRowAtInd
 ```swift
 override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         
-    if tableView.isEqual(tableView) {
+    if tableView.isEqual(self.autoCompletionView) {
         var item = self.searchResult[indexPath.row]
         item += " "  // Adding a space helps dismissing the auto-completion view
             


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've added a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've listed my changes on the [Changelog(https://github.com/slackhq/SlackTextViewController/blob/master/CHANGELOG.md) file.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Fixed typo in README in Swift `tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath)` example concerning the `autoCompletionView`.

The previous example implementation was comparing the ViewController's `tableView` to itself instead of comparing the ViewController's `tableView` to its `autoCompletionView`, which is the intended behavior.


#### Related Issues
> N/A

#### Test strategy
> N/A
