### PR TITLE
Declare framework dependencies in podspec to enable compiling with ccache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Version 1.9.7](https://github.com/slackhq/SlackTextViewController/releases/tag/v1.9.7)
+
+#### Features:
+
+- Enables building the CocoaPod with `CLANG_MODULES_ENABLED=NO` which enables compiling with `ccache`.
+
 ## [Version 1.9.6](https://github.com/slackhq/SlackTextViewController/releases/tag/v1.9.6)
 
 This release includes many iOS 11 and iPhone X hot fixes.

--- a/SlackTextViewController.podspec
+++ b/SlackTextViewController.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.author       		= { "Slack Technologies, Inc." => "ios-team@slack-corp.com" }
   s.source          = { :git => "https://github.com/slackhq/SlackTextViewController.git", :tag => "v#{s.version}" }
 
+  s.frameworks    	= 'CoreGraphics', 'UIKit'
   s.platform     		= :ios, "7.0"
   s.requires_arc 		= true
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've added a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've listed my changes on the [Changelog(https://github.com/slackhq/SlackTextViewController/blob/master/CHANGELOG.md) file.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Users may want to build the pod with Clang modules disabled `-fno-modules` because they are using `ccache` which doesn't support `-fmodules`. When modules are disabled, auto-linking of framework modules is also disabled, so these dependencies need to be expressed explicitly.
