### PR TITLE
Provide a warning to implementor when container view has mismatched configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Version 1.9.7](https://github.com/slackhq/SlackTextViewController/releases/tag/v1.9.7)
+- Add a warning to console about potential configuration issues when embedding SlackTextViewController into a UIContainerView when there is a configuration mismatch between SlackTextViewController and parent. By @rromanchuk (#668)
 
 #### Features:
 

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -432,7 +432,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         // Considers the bottom tab bar, unless it will be hidden
         if (tabBar && !tabBar.hidden && !self.hidesBottomBarWhenPushed) {
             if (self.parentController && self.parentController.hidesBottomBarWhenPushed != self.hidesBottomBarWhenPushed) {
-                NSLog(@"WARNING!!!: Your SLKTextViewController is inside a UIContainerView that has a different setting for hidesBottomBarWhenPushed. If unintended, this will lead to incorrect bottom margin calculations.");
+                NSLog(@"WARNING!!!: Your SLKTextViewController is inside a Container View that has a different setting for hidesBottomBarWhenPushed. If unintended, this will lead to incorrect bottom margin calculations.");
             }
             return CGRectGetHeight(tabBar.frame);
         }

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -431,6 +431,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         
         // Considers the bottom tab bar, unless it will be hidden
         if (tabBar && !tabBar.hidden && !self.hidesBottomBarWhenPushed) {
+            if (self.parentController && self.parentController.hidesBottomBarWhenPushed != self.hidesBottomBarWhenPushed) {
+                NSLog(@"WARNING!!!: Your SLKTextViewController is inside a UIContainerView that has a different setting for hidesBottomBarWhenPushed. If unintended, this will lead to incorrect bottom margin calculations.");
+            }
             return CGRectGetHeight(tabBar.frame);
         }
     }


### PR DESCRIPTION
Embedding `SLKTextViewController` in a container view will most likely cause an incorrect bottom margin calculation. Especially when storyboarding as  https://github.com/slackhq/SlackTextViewController/issues/668

* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've added a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've listed my changes on the [Changelog(https://github.com/slackhq/SlackTextViewController/blob/master/CHANGELOG.md) file.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Scream at user if there is a tabbar inside a container view and its configuration differs from its parent.  

#### Related Issues
Fixes for #668 and #680 

#### Test strategy
NOOP, adds a console warning to potentially reduce headaches. This could and probably be branched, as it's almost never what the implementor intended. Or simply could take the parentViewController's properties when not null (meaning it's in a container). When storyboarding and running, the tabbar isn't shown, and respects the parent's setting, but `SlackTextViewController` reads this property on the container and provides an incorrect margin making this very difficult to track down and debug. 
